### PR TITLE
Add ETA display to dashboard

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Something is broken or behaving incorrectly
-labels: bug, needs-triage
+labels: bug
 ---
 
 ## Describe the bug
@@ -24,13 +24,12 @@ labels: bug, needs-triage
 
 ## Environment
 
-- Server OS:
-- Node.js version (`node --version`):
-- puzzpool version / commit:
-- Worker client (if applicable):
+- URL (prod / test):
+- Browser / client:
+- Server version / commit:
 
 ## Logs
 
 ```
-# Paste relevant server logs here (journalctl -u puzzpool -n 50)
+# Paste relevant logs here (journalctl -u puzzpool -n 50 or browser console)
 ```

--- a/.github/workflows/analyze-bug.yml
+++ b/.github/workflows/analyze-bug.yml
@@ -1,0 +1,88 @@
+name: Analyze bug report
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  analyze:
+    if: github.event.label.name == 'bug'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Call Claude API and post analysis
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          SYSTEM="You are a senior developer reviewing bug reports for puzzpool — a distributed Bitcoin keyspace search pool. The server is Express + SQLite (better-sqlite3). Workers request keyspace chunks via REST API, scan them, and submit results. There is a vanilla JS dashboard and an admin API."
+
+          USER_PROMPT="A tester filed the following bug report.
+
+          Title: ${ISSUE_TITLE}
+
+          Body:
+          ${ISSUE_BODY}
+
+          Analyze the bug and respond using this exact format — no preamble, no sign-off:
+
+          ## Bug analysis
+          [1-3 sentences: what is likely broken and why, based on the report]
+
+          ## Likely root cause
+          [specific component or code area suspected: server.js, public/index.html, nginx config, etc.]
+
+          ## Proposed fix approach
+          [concrete description of what should be changed to fix it — specific enough for a developer to act on]
+
+          ## Verification steps
+          [how the tester should verify the fix worked — 2-4 steps]
+
+          ## Severity
+          [Critical / High / Medium / Low — with one-line justification]"
+
+          PAYLOAD=$(jq -n \
+            --arg model "claude-haiku-4-5-20251001" \
+            --arg system "$SYSTEM" \
+            --arg user "$USER_PROMPT" \
+            '{
+              model: $model,
+              max_tokens: 1024,
+              system: $system,
+              messages: [{ role: "user", content: $user }]
+            }')
+
+          HTTP_STATUS=$(curl -s -o /tmp/claude_response.json -w "%{http_code}" \
+            https://api.anthropic.com/v1/messages \
+            -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "$PAYLOAD")
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "Claude API returned HTTP $HTTP_STATUS:"
+            cat /tmp/claude_response.json
+            exit 1
+          fi
+
+          ANALYSIS=$(jq -r '.content[0].text' /tmp/claude_response.json)
+
+          cat > /tmp/comment.md <<'EOF'
+## Bug triage
+EOF
+          echo "" >> /tmp/comment.md
+          echo "$ANALYSIS" >> /tmp/comment.md
+          echo "" >> /tmp/comment.md
+          cat >> /tmp/comment.md <<'EOF'
+---
+*A developer will review this analysis and propose a fix. Once the fix is implemented and deployed to test, comment `/fix-confirmed` if resolved or `/fix-rejected` if the issue persists.*
+EOF
+
+          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body-file /tmp/comment.md
+          gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --remove-label "bug" --add-label "needs-fix-approval"

--- a/.github/workflows/analyze-bug.yml
+++ b/.github/workflows/analyze-bug.yml
@@ -73,16 +73,7 @@ jobs:
 
           ANALYSIS=$(jq -r '.content[0].text' /tmp/claude_response.json)
 
-          cat > /tmp/comment.md <<'EOF'
-## Bug triage
-EOF
-          echo "" >> /tmp/comment.md
-          echo "$ANALYSIS" >> /tmp/comment.md
-          echo "" >> /tmp/comment.md
-          cat >> /tmp/comment.md <<'EOF'
----
-*A developer will review this analysis and propose a fix. Once the fix is implemented and deployed to test, comment `/fix-confirmed` if resolved or `/fix-rejected` if the issue persists.*
-EOF
+          printf '## Bug triage\n\n%s\n\n---\n*A developer will review this analysis and propose a fix. Once the fix is implemented and deployed to test, comment `/fix-confirmed` if resolved or `/fix-rejected` if the issue persists.*\n' "$ANALYSIS" > /tmp/comment.md
 
           gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body-file /tmp/comment.md
           gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --remove-label "bug" --add-label "needs-fix-approval"

--- a/.github/workflows/confirm-fix.yml
+++ b/.github/workflows/confirm-fix.yml
@@ -1,0 +1,50 @@
+name: Confirm or reject fix
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  confirmed:
+    if: |
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '/fix-confirmed')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close issue as resolved
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" \
+            --remove-label "fix-approved" \
+            --add-label "resolved"
+          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" \
+            --body "Fix confirmed by @${COMMENTER}. Closing issue."
+          gh issue close "${ISSUE_NUMBER}" --repo "${REPO}"
+
+  rejected:
+    if: |
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '/fix-rejected')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Flag issue for rework
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" \
+            --remove-label "fix-approved" \
+            --add-label "fix-rejected"
+          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" \
+            --body "Fix rejected by @${COMMENTER}. Please describe what still fails so the developer can investigate."
+          gh issue reopen "${ISSUE_NUMBER}" --repo "${REPO}"

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ sudo certbot --nginx -d your.domain.com
 See [deploy/nginx.conf](deploy/nginx.conf) and [deploy/puzzpool.service](deploy/puzzpool.service)
 for annotated configuration files.
 
+### Test instance (feature branch testing)
+
+A separate test instance can run on the same server at a different subdomain and port.
+See [deploy/nginx-test.conf](deploy/nginx-test.conf) and [deploy/puzzpool-test.service](deploy/puzzpool-test.service).
+It uses port `8889` and `~/git/puzzpool.test/` as its working directory, so production is never affected.
+
 ---
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 Distributed Bitcoin keyspace search pool. Workers request chunks of a puzzle's keyspace,
 scan them for matching private keys, and report results. A live dashboard visualises
-progress in real time using three canvas-based views: a 1D progress bar, a 2D heatmap,
-and a Hilbert curve projection.
+progress in real time: stat cards (hashrate, ETA, keys completed), three canvas-based views
+(1D progress bar, 2D heatmap, Hilbert curve projection), and live worker/score tables.
 
 **Live instance:** https://puzzle.b58.de
 

--- a/deploy/nginx-test.conf
+++ b/deploy/nginx-test.conf
@@ -1,0 +1,71 @@
+# puzzpool TEST instance — Nginx reverse proxy configuration
+# Serves test.puzzle.b58.de → 127.0.0.1:8889
+#
+# Install:
+#   sudo cp deploy/nginx-test.conf /etc/nginx/sites-available/puzzpool-test
+#   sudo ln -s /etc/nginx/sites-available/puzzpool-test /etc/nginx/sites-enabled/
+#   sudo nginx -t && sudo systemctl reload nginx
+#
+# Then issue the certificate (HTTP-01 challenge via Nginx):
+#   sudo certbot --nginx -d test.puzzle.b58.de
+#
+# Certbot will update the SSL block below automatically.
+# After that, reload nginx and start the service:
+#   sudo systemctl reload nginx
+#   sudo systemctl enable --now puzzpool-test
+
+# Redirect HTTP → HTTPS
+server {
+    listen 80;
+    listen [::]:80;
+    server_name test.puzzle.b58.de;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name test.puzzle.b58.de;
+
+    # --- SSL (managed by Certbot) ---
+    ssl_certificate     /etc/letsencrypt/live/test.puzzle.b58.de/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/test.puzzle.b58.de/privkey.pem;
+    include             /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
+
+    # --- Security headers ---
+    add_header X-Content-Type-Options  nosniff;
+    add_header X-Frame-Options         SAMEORIGIN;
+    add_header Referrer-Policy         strict-origin-when-cross-origin;
+
+    # --- Visible test-env banner via response header ---
+    add_header X-Environment test;
+
+    # --- Admin route: localhost only ---
+    location /api/v1/admin/ {
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+
+        proxy_pass         http://127.0.0.1:8889;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # --- Public API and dashboard ---
+    location / {
+        proxy_pass         http://127.0.0.1:8889;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+
+        client_max_body_size 16k;
+        proxy_read_timeout   30s;
+    }
+}

--- a/deploy/puzzpool-test.service
+++ b/deploy/puzzpool-test.service
@@ -1,0 +1,38 @@
+# puzzpool TEST instance — systemd service unit
+#
+# Install:
+#   sudo cp deploy/puzzpool-test.service /etc/systemd/system/puzzpool-test.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now puzzpool-test
+#
+# Manage:
+#   sudo systemctl status  puzzpool-test
+#   sudo systemctl restart puzzpool-test
+#   journalctl -u puzzpool-test -f
+
+[Unit]
+Description=puzzpool TEST — feature branch test instance
+After=network.target
+
+[Service]
+Type=simple
+
+User=john
+WorkingDirectory=/home/john/git/puzzpool.test
+
+ExecStart=/usr/bin/node server.js
+
+Environment=NODE_ENV=production
+Environment=PORT=8889
+Environment=DB_PATH=/home/john/git/puzzpool.test/pool.db
+Environment=TARGET_MINUTES=5
+Environment=TIMEOUT_MINUTES=15
+# Uncomment to enable admin token auth on the test instance:
+# Environment=ADMIN_TOKEN=your-test-token-here
+
+Restart=on-failure
+RestartSec=5s
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/puzzpool-test.service
+++ b/deploy/puzzpool-test.service
@@ -17,14 +17,14 @@ After=network.target
 [Service]
 Type=simple
 
-User=john
-WorkingDirectory=/home/john/git/puzzpool.test
+User=jan
+WorkingDirectory=/home/jan/git/puzzpool.test
 
 ExecStart=/usr/bin/node server.js
 
 Environment=NODE_ENV=production
 Environment=PORT=8889
-Environment=DB_PATH=/home/john/git/puzzpool.test/pool.db
+Environment=DB_PATH=/home/jan/git/puzzpool.test/pool.db
 Environment=TARGET_MINUTES=5
 Environment=TIMEOUT_MINUTES=15
 # Uncomment to enable admin token auth on the test instance:

--- a/deploy/puzzpool.service
+++ b/deploy/puzzpool.service
@@ -18,9 +18,8 @@ After=network.target
 Type=simple
 
 # --- User / working directory ---
-# Replace 'john' with the system user that owns the repo.
-User=john
-WorkingDirectory=/home/john/git/puzzpool
+User=jan
+WorkingDirectory=/home/jan/git/puzzpool
 
 # --- Command ---
 ExecStart=/usr/bin/node server.js
@@ -29,7 +28,7 @@ ExecStart=/usr/bin/node server.js
 # Inline env vars here or point to a file with EnvironmentFile=
 Environment=NODE_ENV=production
 Environment=PORT=8888
-Environment=DB_PATH=/home/john/git/puzzpool/pool.db
+Environment=DB_PATH=/home/jan/git/puzzpool/pool.db
 Environment=TARGET_MINUTES=5
 Environment=TIMEOUT_MINUTES=15
 # Uncomment and set to enable admin API token auth:

--- a/public/index.html
+++ b/public/index.html
@@ -191,11 +191,6 @@
                 <div class="stat-label">Keys Found</div>
                 <div id="found-keys" class="stat-value amber">0</div>
             </div>
-            <div class="stat-card">
-                <div class="stat-label">ETA</div>
-                <div id="eta-value" class="stat-value cyan">—</div>
-                <div id="eta-subtext" class="stat-subtext">at current speed</div>
-            </div>
         </div>
 
         <!-- Active Puzzle -->
@@ -629,7 +624,6 @@
                 if (data.puzzle && data.puzzle.total_keys) {
                     document.getElementById('puzzle-name').textContent = data.puzzle.name;
                     document.getElementById('frontier').textContent = `0x${data.puzzle.start_hex.replace(/^0+/, '')} … 0x${data.puzzle.end_hex.replace(/^0+/, '')}`;
-                    document.getElementById('puzzle-total-keys').textContent = `Keys total: ${formatBigInt(data.puzzle.total_keys)}`;
                     
                     const totalP = BigInt(data.puzzle.total_keys);
                     const comp = BigInt(data.total_keys_completed);
@@ -642,8 +636,7 @@
                     }
 
                     const eta = formatETA(data.puzzle.total_keys, data.total_keys_completed, data.total_hashrate);
-                    document.getElementById('eta-value').textContent = eta;
-                    document.getElementById('eta-subtext').textContent = data.total_hashrate > 0 ? 'at current speed' : 'no active workers';
+                    document.getElementById('puzzle-total-keys').textContent = `Keys total: ${formatBigInt(data.puzzle.total_keys)} | ETA: ${eta}`;
                 }
 
                 g_chunks_vis = data.chunks_vis || [];

--- a/public/index.html
+++ b/public/index.html
@@ -191,6 +191,11 @@
                 <div class="stat-label">Keys Found</div>
                 <div id="found-keys" class="stat-value amber">0</div>
             </div>
+            <div class="stat-card">
+                <div class="stat-label">ETA</div>
+                <div id="eta-value" class="stat-value cyan">—</div>
+                <div id="eta-subtext" class="stat-subtext">at current speed</div>
+            </div>
         </div>
 
         <!-- Active Puzzle -->
@@ -353,6 +358,19 @@
             let s = pct.toFixed(12);
             s = s.replace(/0+$/, '').replace(/\.$/, ''); // Strip trailing zeros
             return s + " %";
+        }
+
+        function formatETA(totalKeys, keysCompleted, hashrate) {
+            if (hashrate <= 0) return '∞';
+            const remaining = BigInt(totalKeys) - BigInt(keysCompleted);
+            if (remaining <= 0n) return 'Complete';
+            const etaSec = Number(remaining) / hashrate;
+            const MINUTE = 60, HOUR = 3600, DAY = 86400, YEAR = 365.25 * DAY;
+            if (etaSec >= YEAR)   return `~${Math.round(etaSec / YEAR)} years`;
+            if (etaSec >= DAY)    return `~${Math.round(etaSec / DAY)} days`;
+            if (etaSec >= HOUR)   return `~${Math.round(etaSec / HOUR)} hours`;
+            if (etaSec >= MINUTE) return `~${Math.round(etaSec / MINUTE)} min`;
+            return '< 1 min';
         }
 
         // ── Canvas Setup ──
@@ -622,6 +640,10 @@
                         const pct = Number(pctBig) / 10**16;
                         document.getElementById('completed-keys-pct').textContent = formatPrecisePercentage(pct);
                     }
+
+                    const eta = formatETA(data.puzzle.total_keys, data.total_keys_completed, data.total_hashrate);
+                    document.getElementById('eta-value').textContent = eta;
+                    document.getElementById('eta-subtext').textContent = data.total_hashrate > 0 ? 'at current speed' : 'no active workers';
                 }
 
                 g_chunks_vis = data.chunks_vis || [];


### PR DESCRIPTION
Closes #1

## Summary
- Adds an **ETA** stat card to the dashboard showing estimated time to complete the puzzle at current scanning speed
- Computed entirely on the frontend using existing `total_keys`, `total_keys_completed`, and `total_hashrate` from `/api/v1/stats` — no server changes
- Displays `∞` when no workers are active, `Complete` when puzzle is done, otherwise rounds to the most significant unit (years → days → hours → min)

## Test plan
- [ ] All 20 existing tests pass (frontend-only change, no API changes)
- [ ] ETA card appears in the stat grid next to "Keys Found"
- [ ] Shows `∞` when `total_hashrate` is 0 with subtext "no active workers"
- [ ] Shows human-readable value with subtext "at current speed" when workers are active
- [ ] Updates automatically every 3 seconds with the poll cycle