### PR TITLE
Add GitHub automation workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Something is broken or behaving incorrectly
-labels: bug, needs-triage
+labels: bug
 ---
 
 ## Describe the bug
@@ -24,13 +24,12 @@ labels: bug, needs-triage
 
 ## Environment
 
-- Server OS:
-- Node.js version (`node --version`):
-- puzzpool version / commit:
-- Worker client (if applicable):
+- URL (prod / test):
+- Browser / client:
+- Server version / commit:
 
 ## Logs
 
 ```
-# Paste relevant server logs here (journalctl -u puzzpool -n 50)
+# Paste relevant logs here (journalctl -u puzzpool -n 50 or browser console)
 ```

--- a/.github/workflows/analyze-bug.yml
+++ b/.github/workflows/analyze-bug.yml
@@ -1,0 +1,79 @@
+name: Analyze bug report
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  analyze:
+    if: github.event.label.name == 'bug'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Call Claude API and post analysis
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          SYSTEM="You are a senior developer reviewing bug reports for puzzpool — a distributed Bitcoin keyspace search pool. The server is Express + SQLite (better-sqlite3). Workers request keyspace chunks via REST API, scan them, and submit results. There is a vanilla JS dashboard and an admin API."
+
+          USER_PROMPT="A tester filed the following bug report.
+
+          Title: ${ISSUE_TITLE}
+
+          Body:
+          ${ISSUE_BODY}
+
+          Analyze the bug and respond using this exact format — no preamble, no sign-off:
+
+          ## Bug analysis
+          [1-3 sentences: what is likely broken and why, based on the report]
+
+          ## Likely root cause
+          [specific component or code area suspected: server.js, public/index.html, nginx config, etc.]
+
+          ## Proposed fix approach
+          [concrete description of what should be changed to fix it — specific enough for a developer to act on]
+
+          ## Verification steps
+          [how the tester should verify the fix worked — 2-4 steps]
+
+          ## Severity
+          [Critical / High / Medium / Low — with one-line justification]"
+
+          PAYLOAD=$(jq -n \
+            --arg model "claude-haiku-4-5-20251001" \
+            --arg system "$SYSTEM" \
+            --arg user "$USER_PROMPT" \
+            '{
+              model: $model,
+              max_tokens: 1024,
+              system: $system,
+              messages: [{ role: "user", content: $user }]
+            }')
+
+          HTTP_STATUS=$(curl -s -o /tmp/claude_response.json -w "%{http_code}" \
+            https://api.anthropic.com/v1/messages \
+            -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "$PAYLOAD")
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "Claude API returned HTTP $HTTP_STATUS:"
+            cat /tmp/claude_response.json
+            exit 1
+          fi
+
+          ANALYSIS=$(jq -r '.content[0].text' /tmp/claude_response.json)
+
+          printf '## Bug triage\n\n%s\n\n---\n*A developer will review this analysis and propose a fix. Once the fix is implemented and deployed to test, comment `/fix-confirmed` if resolved or `/fix-rejected` if the issue persists.*\n' "$ANALYSIS" > /tmp/comment.md
+
+          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body-file /tmp/comment.md
+          gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --remove-label "bug" --add-label "needs-fix-approval"

--- a/.github/workflows/confirm-fix.yml
+++ b/.github/workflows/confirm-fix.yml
@@ -1,0 +1,50 @@
+name: Confirm or reject fix
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  confirmed:
+    if: |
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '/fix-confirmed')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close issue as resolved
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" \
+            --remove-label "fix-approved" \
+            --add-label "resolved"
+          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" \
+            --body "Fix confirmed by @${COMMENTER}. Closing issue."
+          gh issue close "${ISSUE_NUMBER}" --repo "${REPO}"
+
+  rejected:
+    if: |
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '/fix-rejected')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Flag issue for rework
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" \
+            --remove-label "fix-approved" \
+            --add-label "fix-rejected"
+          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" \
+            --body "Fix rejected by @${COMMENTER}. Please describe what still fails so the developer can investigate."
+          gh issue reopen "${ISSUE_NUMBER}" --repo "${REPO}"


### PR DESCRIPTION
## Summary
- `refine-feature.yml` — auto-generates user story when `feature-idea` label is applied
- `approve-feature.yml` — moves feature to `approved` on `/approve` comment
- `analyze-bug.yml` — auto-analyzes bug reports when `bug` label is applied
- `confirm-fix.yml` — closes issue on `/fix-confirmed`, reopens on `/fix-rejected`
- Updated issue templates to match the new label-based workflow

## Why this needs to land on main first
Issue/comment event workflows only run from the default branch. These are currently stuck on `feat/eta-display` and not triggering.

## Test plan
- [ ] CI passes
- [ ] Merge to main
- [ ] Open a test bug issue → verify `analyze-bug` fires and posts analysis comment
- [ ] Comment `/fix-confirmed` → verify issue auto-closes with `resolved` label