### PR TITLE
Add multi-keyspace support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,12 @@ TIMEOUT_MINUTES=15
 # Leave blank (or unset) to disable auth (suitable for localhost-only deployments
 # where Nginx restricts admin routes by IP).
 ADMIN_TOKEN=
+
+# Keyspace definitions — any number of KEYSPACE_<NAME>=<start_hex>:<end_hex> entries.
+# NAME (underscores replaced with spaces) becomes the puzzle name in the dashboard.
+# On startup, missing puzzles are seeded automatically (inactive by default).
+# The first puzzle in the DB is activated if none is currently active.
+#
+# Example:
+# KEYSPACE_PUZZLE_71=0x0400000000000000000:0x07fffffffffffffffff
+# KEYSPACE_ALL_BTC=0x1:0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141

--- a/deploy/nginx-test.conf
+++ b/deploy/nginx-test.conf
@@ -42,7 +42,19 @@ server {
     # --- Visible test-env banner via response header ---
     add_header X-Environment test;
 
-    # --- Admin route: localhost only ---
+    # --- activate-puzzle: called from dashboard browser, allow public access ---
+    # Server-side ADMIN_TOKEN auth still applies if configured.
+    location /api/v1/admin/activate-puzzle {
+        proxy_pass         http://127.0.0.1:8889;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        client_max_body_size 16k;
+    }
+
+    # --- All other admin routes: localhost only ---
     location /api/v1/admin/ {
         allow 127.0.0.1;
         allow ::1;

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -34,9 +34,20 @@ server {
     add_header X-Frame-Options         SAMEORIGIN;
     add_header Referrer-Policy         strict-origin-when-cross-origin;
 
-    # --- Admin route IP restriction ---
+    # --- activate-puzzle: called from dashboard browser, allow public access ---
+    # Server-side ADMIN_TOKEN auth still applies if configured.
+    location /api/v1/admin/activate-puzzle {
+        proxy_pass         http://127.0.0.1:8888;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        client_max_body_size 16k;
+    }
+
+    # --- All other admin routes: IP restriction ---
     # Only allow admin API calls from localhost and your trusted management IP.
-    # Remove or expand this block if you use ADMIN_TOKEN auth instead.
     location /api/v1/admin/ {
         allow 127.0.0.1;
         allow ::1;

--- a/deploy/puzzpool-test.service
+++ b/deploy/puzzpool-test.service
@@ -22,6 +22,7 @@ WorkingDirectory=/home/jan/git/puzzpool.test
 
 ExecStart=/usr/bin/node server.js
 
+EnvironmentFile=/home/jan/git/puzzpool.test/.env
 Environment=NODE_ENV=production
 Environment=PORT=8889
 Environment=DB_PATH=/home/jan/git/puzzpool.test/pool.db

--- a/deploy/puzzpool.service
+++ b/deploy/puzzpool.service
@@ -25,7 +25,7 @@ WorkingDirectory=/home/jan/git/puzzpool
 ExecStart=/usr/bin/node server.js
 
 # --- Environment ---
-# Inline env vars here or point to a file with EnvironmentFile=
+EnvironmentFile=/home/jan/git/puzzpool/.env
 Environment=NODE_ENV=production
 Environment=PORT=8888
 Environment=DB_PATH=/home/jan/git/puzzpool/pool.db

--- a/docs/api.md
+++ b/docs/api.md
@@ -102,6 +102,10 @@ Dashboard data — polled every 3 seconds by `index.html`.
 **Response 200** (abbreviated)
 ```json
 {
+  "puzzles": [
+    { "id": 1, "name": "Puzzle #71", "active": 1 },
+    { "id": 2, "name": "ALL BTC",    "active": 0 }
+  ],
   "puzzle": {
     "id": 1,
     "name": "Puzzle #71",
@@ -184,4 +188,35 @@ List all puzzles (active and historical).
 **Response 200**
 ```json
 { "puzzles": [ { "id": 1, "name": "Puzzle #71", "active": 1, ... } ] }
+```
+
+---
+
+### POST /api/v1/admin/activate-puzzle
+
+Switch the active puzzle. The previously active puzzle is deactivated.
+Workers already scanning chunks from the old puzzle can still submit their results.
+
+**Request**
+```json
+{ "id": 2 }
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | number | yes | ID of the puzzle to activate |
+
+**Response 200**
+```json
+{ "ok": true, "puzzle": { "id": 2, "name": "ALL BTC", "active": 1, ... } }
+```
+
+**Response 400** — missing id
+```json
+{ "error": "Missing id" }
+```
+
+**Response 404** — id not found
+```json
+{ "error": "Puzzle not found" }
 ```

--- a/public/index.html
+++ b/public/index.html
@@ -83,6 +83,7 @@
 
         /* ── Puzzle / frontier card ── */
         .frontier-card { background: linear-gradient(145deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%); border: 1px solid var(--border-default); border-radius: var(--radius); padding: 1.25rem 1.5rem; margin-bottom: 1rem; }
+        .frontier-card.has-tabs { border-radius: 0 var(--radius) var(--radius) var(--radius); border-color: var(--border-hover); }
         .frontier-label { font-size: 0.7rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-secondary); margin-bottom: 0.4rem; }
         .frontier-value { font-family: var(--font-mono); font-size: 0.95rem; color: var(--accent-amber); word-break: break-all; }
 
@@ -147,18 +148,17 @@
         .comment { color: var(--text-muted); }
 
         /* ── Keyspace Tabs ── */
-        .keyspace-tabs { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1rem; }
-        .ks-tab { background: var(--bg-tertiary); border: 1px solid var(--border-default); border-radius: var(--radius); padding: 0.75rem 1.25rem; display: flex; flex-direction: column; align-items: center; gap: 0.6rem; transition: var(--transition); min-width: 130px; }
-        .ks-tab.active { border-color: var(--accent-cyan); background: rgba(0,255,255,0.04); box-shadow: 0 0 15px var(--accent-cyan-glow); }
-        .ks-tab:not(.active) { cursor: pointer; }
-        .ks-tab:not(.active):hover { border-color: var(--border-hover); background: var(--bg-secondary); }
-        .ks-tab-name { font-family: var(--font-mono); font-size: 0.8rem; font-weight: 600; letter-spacing: 0.05em; color: var(--text-secondary); }
-        .ks-tab.active .ks-tab-name { color: var(--accent-cyan); }
+        .keyspace-tabs { display: flex; align-items: flex-end; gap: 0; margin-bottom: -1px; position: relative; z-index: 1; flex-wrap: wrap; }
+        .ks-tab { display: flex; flex-direction: column; align-items: center; gap: 0.45rem; padding: 0.6rem 1.5rem 0.7rem; border: 1px solid var(--border-default); border-bottom: none; border-radius: var(--radius) var(--radius) 0 0; background: var(--bg-secondary); cursor: pointer; transition: var(--transition); margin-right: 3px; min-width: 110px; }
+        .ks-tab.active { background: linear-gradient(145deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%); border-color: var(--border-hover); border-bottom: 1px solid var(--bg-secondary); padding-bottom: 0.85rem; cursor: default; }
+        .ks-tab:not(.active):hover { background: var(--bg-tertiary); border-color: var(--border-hover); }
+        .ks-tab-name { font-family: var(--font-mono); font-size: 0.75rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); white-space: nowrap; }
+        .ks-tab.active .ks-tab-name { color: var(--accent-cyan); text-shadow: 0 0 8px var(--accent-cyan-glow); }
         /* Toggle switch */
-        .ks-toggle { position: relative; width: 40px; height: 22px; flex-shrink: 0; }
+        .ks-toggle { position: relative; width: 38px; height: 20px; flex-shrink: 0; }
         .ks-toggle input { opacity: 0; width: 0; height: 0; position: absolute; }
-        .ks-toggle-slider { position: absolute; inset: 0; background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: 22px; transition: var(--transition); pointer-events: none; }
-        .ks-toggle-slider::before { content: ""; position: absolute; height: 14px; width: 14px; left: 3px; top: 3px; background: var(--text-muted); border-radius: 50%; transition: var(--transition); }
+        .ks-toggle-slider { position: absolute; inset: 0; background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: 20px; transition: var(--transition); pointer-events: none; }
+        .ks-toggle-slider::before { content: ""; position: absolute; height: 12px; width: 12px; left: 3px; top: 3px; background: var(--text-muted); border-radius: 50%; transition: var(--transition); }
         .ks-toggle input:checked + .ks-toggle-slider { background: rgba(0,255,255,0.15); border-color: var(--accent-cyan); }
         .ks-toggle input:checked + .ks-toggle-slider::before { transform: translateX(18px); background: var(--accent-cyan); box-shadow: 0 0 6px var(--accent-cyan); }
 
@@ -418,8 +418,14 @@
 
         function renderKeyspaceTabs(puzzles) {
             const container = document.getElementById('keyspace-tabs');
-            if (!puzzles || puzzles.length <= 1) { container.style.display = 'none'; return; }
+            const frontierCard = document.querySelector('.frontier-card');
+            if (!puzzles || puzzles.length <= 1) {
+                container.style.display = 'none';
+                frontierCard.classList.remove('has-tabs');
+                return;
+            }
             container.style.display = 'flex';
+            frontierCard.classList.add('has-tabs');
             container.innerHTML = puzzles.map(p => `
                 <div class="ks-tab${p.active ? ' active' : ''}" data-id="${p.id}">
                     <span class="ks-tab-name">${p.name}</span>

--- a/public/index.html
+++ b/public/index.html
@@ -83,7 +83,6 @@
 
         /* ── Puzzle / frontier card ── */
         .frontier-card { background: linear-gradient(145deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%); border: 1px solid var(--border-default); border-radius: var(--radius); padding: 1.25rem 1.5rem; margin-bottom: 1rem; }
-        .frontier-card.has-tabs { border-radius: 0 var(--radius) var(--radius) var(--radius); border-color: var(--border-hover); }
         .frontier-label { font-size: 0.7rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-secondary); margin-bottom: 0.4rem; }
         .frontier-value { font-family: var(--font-mono); font-size: 0.95rem; color: var(--accent-amber); word-break: break-all; }
 
@@ -148,16 +147,27 @@
         .comment { color: var(--text-muted); }
 
         /* ── Keyspace Tabs ── */
-        .keyspace-tabs { display: flex; align-items: flex-end; gap: 0; margin-bottom: -1px; position: relative; z-index: 1; flex-wrap: wrap; }
-        .ks-tab { display: flex; flex-direction: column; align-items: center; gap: 0.45rem; padding: 0.6rem 1.5rem 0.7rem; border: 1px solid var(--border-default); border-bottom: none; border-radius: var(--radius) var(--radius) 0 0; background: var(--bg-secondary); cursor: pointer; transition: var(--transition); margin-right: 3px; min-width: 110px; }
-        .ks-tab.active { background: linear-gradient(145deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%); border-color: var(--border-hover); border-bottom: 1px solid var(--bg-secondary); padding-bottom: 0.85rem; cursor: default; }
-        .ks-tab:not(.active):hover { background: var(--bg-tertiary); border-color: var(--border-hover); }
-        .ks-tab-name { font-family: var(--font-mono); font-size: 0.75rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); white-space: nowrap; }
-        .ks-tab.active .ks-tab-name { color: var(--accent-cyan); text-shadow: 0 0 8px var(--accent-cyan-glow); }
+        /* Header: remove bottom spacing when keyspace nav is visible */
+        .header.has-ks-tabs { margin-bottom: 0; padding-bottom: 1rem; border-bottom: none; }
+
+        /* Keyspace nav wrapper */
+        #ks-nav { margin-bottom: 2rem; }
+
+        /* Tab strip — sits right below the header, tabs connect to the separator line */
+        #ks-tab-strip { display: flex; align-items: flex-end; gap: 3px; border-bottom: 1px solid var(--border-default); }
+        .ks-tab { font-family: var(--font-mono); font-size: 0.75rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); cursor: pointer; padding: 0.5rem 1.5rem 0.6rem; border: 1px solid transparent; border-bottom: none; border-radius: var(--radius) var(--radius) 0 0; background: transparent; transition: var(--transition); white-space: nowrap; min-width: 110px; text-align: center; margin-bottom: -1px; position: relative; }
+        .ks-tab.active { color: var(--accent-cyan); text-shadow: 0 0 8px var(--accent-cyan-glow); border-color: var(--border-default); background: var(--bg-secondary); border-bottom: 1px solid var(--bg-secondary); cursor: default; }
+        .ks-tab:not(.active):hover { color: var(--text-primary); background: var(--bg-tertiary); border-color: var(--border-hover); }
+
+        /* Toggle strip — separate row below the tab separator line */
+        #ks-toggle-strip { display: flex; gap: 3px; padding: 0.65rem 0; border-bottom: 1px solid var(--border-default); }
+        .ks-toggle-cell { min-width: 110px; display: flex; justify-content: center; align-items: center; cursor: pointer; }
+        .ks-toggle-cell[data-active] { cursor: default; }
+
         /* Toggle switch */
-        .ks-toggle { position: relative; width: 38px; height: 20px; flex-shrink: 0; }
+        .ks-toggle { position: relative; width: 38px; height: 20px; flex-shrink: 0; pointer-events: none; }
         .ks-toggle input { opacity: 0; width: 0; height: 0; position: absolute; }
-        .ks-toggle-slider { position: absolute; inset: 0; background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: 20px; transition: var(--transition); pointer-events: none; }
+        .ks-toggle-slider { position: absolute; inset: 0; background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: 20px; transition: var(--transition); }
         .ks-toggle-slider::before { content: ""; position: absolute; height: 12px; width: 12px; left: 3px; top: 3px; background: var(--text-muted); border-radius: 50%; transition: var(--transition); }
         .ks-toggle input:checked + .ks-toggle-slider { background: rgba(0,255,255,0.15); border-color: var(--accent-cyan); }
         .ks-toggle input:checked + .ks-toggle-slider::before { transform: translateX(18px); background: var(--accent-cyan); box-shadow: 0 0 6px var(--accent-cyan); }
@@ -202,6 +212,12 @@
             <div class="status-badge"><div class="status-dot"></div>ONLINE</div>
         </div>
 
+        <!-- Keyspace navigation: tab strip + toggle strip (hidden when ≤1 puzzle) -->
+        <div id="ks-nav" style="display:none">
+            <div id="ks-tab-strip"></div>
+            <div id="ks-toggle-strip"></div>
+        </div>
+
         <!-- Stat cards (Dynamic Flex Grid) -->
         <div class="stat-grid">
             <div class="stat-card">
@@ -226,9 +242,6 @@
                 <div id="found-keys" class="stat-value amber">0</div>
             </div>
         </div>
-
-        <!-- Keyspace Tabs (hidden when only one puzzle exists) -->
-        <div class="keyspace-tabs" id="keyspace-tabs" style="display:none"></div>
 
         <!-- Active Puzzle -->
         <div class="frontier-card">
@@ -416,33 +429,55 @@
         // ── Keyspace Tabs ──
         let pendingActivateId = null;
 
+        function openActivateModal(id, name) {
+            pendingActivateId = id;
+            document.getElementById('modal-puzzle-name').textContent = name;
+            document.getElementById('modal-token-input').value = sessionStorage.getItem('adminToken') || '';
+            document.getElementById('modal-error').style.display = 'none';
+            document.getElementById('activate-modal').style.display = 'flex';
+        }
+
         function renderKeyspaceTabs(puzzles) {
-            const container = document.getElementById('keyspace-tabs');
-            const frontierCard = document.querySelector('.frontier-card');
+            const nav       = document.getElementById('ks-nav');
+            const tabStrip  = document.getElementById('ks-tab-strip');
+            const togStrip  = document.getElementById('ks-toggle-strip');
+            const header    = document.querySelector('.header');
+
             if (!puzzles || puzzles.length <= 1) {
-                container.style.display = 'none';
-                frontierCard.classList.remove('has-tabs');
+                nav.style.display = 'none';
+                header.classList.remove('has-ks-tabs');
                 return;
             }
-            container.style.display = 'flex';
-            frontierCard.classList.add('has-tabs');
-            container.innerHTML = puzzles.map(p => `
-                <div class="ks-tab${p.active ? ' active' : ''}" data-id="${p.id}">
-                    <span class="ks-tab-name">${p.name}</span>
-                    <label class="ks-toggle" title="${p.active ? 'Active keyspace' : 'Click to activate'}">
-                        <input type="checkbox" ${p.active ? 'checked disabled' : ''}>
+
+            nav.style.display = 'block';
+            header.classList.add('has-ks-tabs');
+
+            // Tab strip — puzzle names only
+            tabStrip.innerHTML = puzzles.map(p =>
+                `<div class="ks-tab${p.active ? ' active' : ''}" data-id="${p.id}">${p.name}</div>`
+            ).join('');
+
+            // Toggle strip — one toggle per puzzle, aligned under its tab
+            togStrip.innerHTML = puzzles.map(p =>
+                `<div class="ks-toggle-cell"${p.active ? ' data-active="1"' : ''} data-id="${p.id}">
+                    <label class="ks-toggle">
+                        <input type="checkbox"${p.active ? ' checked disabled' : ''}>
                         <span class="ks-toggle-slider"></span>
                     </label>
                 </div>`
             ).join('');
-            container.querySelectorAll('.ks-tab:not(.active)').forEach(tab => {
-                tab.addEventListener('click', () => {
-                    pendingActivateId = parseInt(tab.dataset.id);
-                    document.getElementById('modal-puzzle-name').textContent = tab.querySelector('.ks-tab-name').textContent;
-                    document.getElementById('modal-token-input').value = sessionStorage.getItem('adminToken') || '';
-                    document.getElementById('modal-error').style.display = 'none';
-                    document.getElementById('activate-modal').style.display = 'flex';
-                });
+
+            // Wire inactive tabs → modal
+            tabStrip.querySelectorAll('.ks-tab:not(.active)').forEach(tab => {
+                tab.addEventListener('click', () =>
+                    openActivateModal(parseInt(tab.dataset.id), tab.textContent.trim()));
+            });
+
+            // Wire inactive toggle cells → modal
+            togStrip.querySelectorAll('.ks-toggle-cell:not([data-active])').forEach(cell => {
+                const p = puzzles.find(p2 => p2.id === parseInt(cell.dataset.id));
+                cell.addEventListener('click', () =>
+                    openActivateModal(parseInt(cell.dataset.id), p ? p.name : cell.dataset.id));
             });
         }
 

--- a/public/index.html
+++ b/public/index.html
@@ -448,12 +448,12 @@
                 });
                 if (res.ok) {
                     updateDashboard();
-                } else if (res.status === 401) {
-                    // Token missing or wrong — fall back to modal so user can enter it
+                } else {
+                    // Any error (401 = bad token, 4xx/5xx) → open modal so user can review/enter token
+                    if (res.status === 401) sessionStorage.removeItem('adminToken');
                     openActivateModal(id, name);
                 }
             } catch (e) {
-                // Network error — open modal so user can retry
                 openActivateModal(id, name);
             }
         }

--- a/public/index.html
+++ b/public/index.html
@@ -147,10 +147,20 @@
         .comment { color: var(--text-muted); }
 
         /* ── Keyspace Tabs ── */
-        .keyspace-tabs { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
-        .ks-tab-btn { font-family: var(--font-mono); font-size: 0.75rem; font-weight: 600; padding: 0.4rem 1rem; border-radius: var(--radius); border: 1px solid var(--border-default); background: var(--bg-tertiary); color: var(--text-secondary); cursor: pointer; transition: var(--transition); letter-spacing: 0.05em; }
-        .ks-tab-btn.active { border-color: var(--accent-cyan); color: var(--accent-cyan); background: rgba(0,255,255,0.06); cursor: default; }
-        .ks-tab-btn:not(.active):hover { border-color: var(--border-hover); color: var(--text-primary); }
+        .keyspace-tabs { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1rem; }
+        .ks-tab { background: var(--bg-tertiary); border: 1px solid var(--border-default); border-radius: var(--radius); padding: 0.75rem 1.25rem; display: flex; flex-direction: column; align-items: center; gap: 0.6rem; transition: var(--transition); min-width: 130px; }
+        .ks-tab.active { border-color: var(--accent-cyan); background: rgba(0,255,255,0.04); box-shadow: 0 0 15px var(--accent-cyan-glow); }
+        .ks-tab:not(.active) { cursor: pointer; }
+        .ks-tab:not(.active):hover { border-color: var(--border-hover); background: var(--bg-secondary); }
+        .ks-tab-name { font-family: var(--font-mono); font-size: 0.8rem; font-weight: 600; letter-spacing: 0.05em; color: var(--text-secondary); }
+        .ks-tab.active .ks-tab-name { color: var(--accent-cyan); }
+        /* Toggle switch */
+        .ks-toggle { position: relative; width: 40px; height: 22px; flex-shrink: 0; }
+        .ks-toggle input { opacity: 0; width: 0; height: 0; position: absolute; }
+        .ks-toggle-slider { position: absolute; inset: 0; background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: 22px; transition: var(--transition); pointer-events: none; }
+        .ks-toggle-slider::before { content: ""; position: absolute; height: 14px; width: 14px; left: 3px; top: 3px; background: var(--text-muted); border-radius: 50%; transition: var(--transition); }
+        .ks-toggle input:checked + .ks-toggle-slider { background: rgba(0,255,255,0.15); border-color: var(--accent-cyan); }
+        .ks-toggle input:checked + .ks-toggle-slider::before { transform: translateX(18px); background: var(--accent-cyan); box-shadow: 0 0 6px var(--accent-cyan); }
 
         /* ── Activation Modal ── */
         .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.75); display: flex; align-items: center; justify-content: center; z-index: 1000; }
@@ -410,13 +420,19 @@
             const container = document.getElementById('keyspace-tabs');
             if (!puzzles || puzzles.length <= 1) { container.style.display = 'none'; return; }
             container.style.display = 'flex';
-            container.innerHTML = puzzles.map(p =>
-                `<button class="ks-tab-btn${p.active ? ' active' : ''}" data-id="${p.id}">${p.name}</button>`
+            container.innerHTML = puzzles.map(p => `
+                <div class="ks-tab${p.active ? ' active' : ''}" data-id="${p.id}">
+                    <span class="ks-tab-name">${p.name}</span>
+                    <label class="ks-toggle" title="${p.active ? 'Active keyspace' : 'Click to activate'}">
+                        <input type="checkbox" ${p.active ? 'checked disabled' : ''}>
+                        <span class="ks-toggle-slider"></span>
+                    </label>
+                </div>`
             ).join('');
-            container.querySelectorAll('.ks-tab-btn:not(.active)').forEach(btn => {
-                btn.addEventListener('click', () => {
-                    pendingActivateId = parseInt(btn.dataset.id);
-                    document.getElementById('modal-puzzle-name').textContent = btn.textContent;
+            container.querySelectorAll('.ks-tab:not(.active)').forEach(tab => {
+                tab.addEventListener('click', () => {
+                    pendingActivateId = parseInt(tab.dataset.id);
+                    document.getElementById('modal-puzzle-name').textContent = tab.querySelector('.ks-tab-name').textContent;
                     document.getElementById('modal-token-input').value = sessionStorage.getItem('adminToken') || '';
                     document.getElementById('modal-error').style.display = 'none';
                     document.getElementById('activate-modal').style.display = 'flex';

--- a/public/index.html
+++ b/public/index.html
@@ -155,16 +155,17 @@
 
         /* Tab strip — sits right below the header, tabs connect to the separator line */
         #ks-tab-strip { display: flex; align-items: flex-end; gap: 3px; border-bottom: 1px solid var(--border-default); }
-        .ks-tab { font-family: var(--font-mono); font-size: 0.75rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); cursor: pointer; padding: 0.5rem 1.5rem 0.6rem; border: 1px solid transparent; border-bottom: none; border-radius: var(--radius) var(--radius) 0 0; background: transparent; transition: var(--transition); white-space: nowrap; min-width: 110px; text-align: center; margin-bottom: -1px; position: relative; }
+        .ks-tab { flex: 1; font-family: var(--font-mono); font-size: 0.75rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); cursor: pointer; padding: 0.5rem 1.5rem 0.6rem; border: 1px solid transparent; border-bottom: none; border-radius: var(--radius) var(--radius) 0 0; background: transparent; transition: var(--transition); white-space: nowrap; text-align: center; margin-bottom: -1px; position: relative; }
         .ks-tab.active { color: var(--accent-cyan); text-shadow: 0 0 8px var(--accent-cyan-glow); border-color: var(--border-default); background: var(--bg-secondary); border-bottom: 1px solid var(--bg-secondary); cursor: default; }
         .ks-tab:not(.active):hover { color: var(--text-primary); background: var(--bg-tertiary); border-color: var(--border-hover); }
 
         /* Toggle strip — separate row below the tab separator line */
         #ks-toggle-strip { display: flex; gap: 3px; padding: 0.65rem 0; }
-        .ks-toggle-cell { min-width: 110px; display: flex; justify-content: center; align-items: center; cursor: pointer; }
+        /* flex: 1 matches each cell to its tab column → toggle is always centered under its tab */
+        .ks-toggle-cell { flex: 1; display: flex; justify-content: center; align-items: center; cursor: pointer; }
         .ks-toggle-cell[data-active] { cursor: default; }
-        /* Show toggle only under the active tab; inactive cells keep their space for alignment */
-        .ks-toggle-cell:not([data-active]) { visibility: hidden; }
+        /* Inactive cells: invisible, non-clickable, but still occupy space for alignment */
+        .ks-toggle-cell:not([data-active]) { visibility: hidden; pointer-events: none; }
 
         /* Toggle switch */
         .ks-toggle { position: relative; width: 38px; height: 20px; flex-shrink: 0; pointer-events: none; }
@@ -430,6 +431,7 @@
 
         // ── Keyspace Tabs ──
         let pendingActivateId = null;
+        let _lastPuzzles = [];   // cache for optimistic re-render on activation
 
         function openActivateModal(id, name) {
             pendingActivateId = id;
@@ -449,6 +451,8 @@
                     body: JSON.stringify({ id })
                 });
                 if (res.ok) {
+                    renderKeyspaceTabs(_lastPuzzles.map(p =>
+                        ({...p, active: p.id === id ? 1 : 0})));
                     updateDashboard();
                 } else {
                     // Any error (401 = bad token, 4xx/5xx) → open modal so user can review/enter token
@@ -461,6 +465,7 @@
         }
 
         function renderKeyspaceTabs(puzzles) {
+            _lastPuzzles = puzzles || [];
             const nav       = document.getElementById('ks-nav');
             const tabStrip  = document.getElementById('ks-tab-strip');
             const togStrip  = document.getElementById('ks-toggle-strip');
@@ -523,6 +528,10 @@
                 if (res.ok) {
                     if (token) sessionStorage.setItem('adminToken', token);
                     document.getElementById('activate-modal').style.display = 'none';
+                    // Optimistic re-render: flip active flag locally so the UI updates
+                    // instantly without waiting for the next updateDashboard round-trip.
+                    renderKeyspaceTabs(_lastPuzzles.map(p =>
+                        ({...p, active: p.id === pendingActivateId ? 1 : 0})));
                     pendingActivateId = null;
                     updateDashboard();
                 } else {

--- a/public/index.html
+++ b/public/index.html
@@ -449,7 +449,7 @@
                 if (res.ok) {
                     renderKeyspaceTabs(_lastPuzzles.map(p =>
                         ({...p, active: p.id === id ? 1 : 0})));
-                    updateDashboard();
+                    updateDashboard(); // confirm from server
                 } else {
                     // Any error (401 = bad token, 4xx/5xx) → open modal so user can review/enter token
                     if (res.status === 401) sessionStorage.removeItem('adminToken');
@@ -461,47 +461,57 @@
         }
 
         function renderKeyspaceTabs(puzzles) {
-            _lastPuzzles = puzzles || [];
+            // Normalize active to strict boolean — guards against "0"/"1" strings,
+            // integers, or any other truthy/falsy surprise from the API.
+            const normalized = (puzzles || []).map(p => ({
+                ...p,
+                active: p.active === true || p.active === 1 || p.active === '1'
+            }));
+
+            // Enforce exactly ONE active puzzle on the frontend.
+            // Even if the DB returns two active rows, only the first one wins here.
+            let activeIdx = normalized.findIndex(p => p.active);
+            if (activeIdx < 0) activeIdx = 0;
+            const items = normalized.map((p, i) => ({ ...p, active: i === activeIdx }));
+
+            _lastPuzzles = items;
+
             const nav      = document.getElementById('ks-nav');
             const tabStrip = document.getElementById('ks-tab-strip');
             const togStrip = document.getElementById('ks-toggle-strip');
             const header   = document.querySelector('.header');
 
-            if (!puzzles || puzzles.length <= 1) {
+            if (items.length <= 1) {
                 nav.style.display = 'none';
                 header.classList.remove('has-ks-tabs');
+                tabStrip.innerHTML = '';
+                togStrip.innerHTML = '';
                 return;
             }
 
             nav.style.display = 'block';
             header.classList.add('has-ks-tabs');
 
-            // Both strips use identical grid columns → each toggle cell sits under its tab
-            const gridCols = `repeat(${puzzles.length}, 1fr)`;
+            const gridCols = `repeat(${items.length}, 1fr)`;
             tabStrip.style.gridTemplateColumns = gridCols;
             togStrip.style.gridTemplateColumns = gridCols;
 
-            // Tab strip — names only
-            tabStrip.innerHTML = puzzles.map(p =>
+            tabStrip.innerHTML = items.map(p =>
                 `<div class="ks-tab${p.active ? ' active' : ''}" data-id="${p.id}">${p.name}</div>`
             ).join('');
 
-            // Toggle strip — render ONLY the active toggle, placed in its column via grid-column.
-            // No invisible placeholder cells → it is physically impossible to show two toggles.
-            const activeIdx = puzzles.findIndex(p => p.active);
-            togStrip.innerHTML = activeIdx >= 0
-                ? `<div class="ks-toggle-cell" style="grid-column:${activeIdx + 1}">
-                       <label class="ks-toggle">
-                           <input type="checkbox" checked disabled>
-                           <span class="ks-toggle-slider"></span>
-                       </label>
-                   </div>`
-                : '';
+            // Exactly one toggle cell, placed in the active column.
+            togStrip.innerHTML = `
+                <div class="ks-toggle-cell" style="grid-column:${activeIdx + 1}">
+                    <label class="ks-toggle">
+                        <input type="checkbox" checked disabled>
+                        <span class="ks-toggle-slider"></span>
+                    </label>
+                </div>`;
 
-            // Tab click → instant switch
             tabStrip.querySelectorAll('.ks-tab:not(.active)').forEach(tab => {
                 tab.addEventListener('click', () =>
-                    activatePuzzle(parseInt(tab.dataset.id), tab.textContent.trim()));
+                    activatePuzzle(Number(tab.dataset.id), tab.textContent.trim()));
             });
         }
 
@@ -524,8 +534,6 @@
                 if (res.ok) {
                     if (token) sessionStorage.setItem('adminToken', token);
                     document.getElementById('activate-modal').style.display = 'none';
-                    // Optimistic re-render: flip active flag locally so the UI updates
-                    // instantly without waiting for the next updateDashboard round-trip.
                     renderKeyspaceTabs(_lastPuzzles.map(p =>
                         ({...p, active: p.id === pendingActivateId ? 1 : 0})));
                     pendingActivateId = null;

--- a/public/index.html
+++ b/public/index.html
@@ -146,6 +146,30 @@
         pre.request { color: #7ec8a0; }
         .comment { color: var(--text-muted); }
 
+        /* ── Keyspace Tabs ── */
+        .keyspace-tabs { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+        .ks-tab-btn { font-family: var(--font-mono); font-size: 0.75rem; font-weight: 600; padding: 0.4rem 1rem; border-radius: var(--radius); border: 1px solid var(--border-default); background: var(--bg-tertiary); color: var(--text-secondary); cursor: pointer; transition: var(--transition); letter-spacing: 0.05em; }
+        .ks-tab-btn.active { border-color: var(--accent-cyan); color: var(--accent-cyan); background: rgba(0,255,255,0.06); cursor: default; }
+        .ks-tab-btn:not(.active):hover { border-color: var(--border-hover); color: var(--text-primary); }
+
+        /* ── Activation Modal ── */
+        .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.75); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+        .modal { background: var(--bg-elevated); border: 1px solid var(--border-hover); border-radius: var(--radius); padding: 1.5rem; max-width: 420px; width: 90%; }
+        .modal-title { font-family: var(--font-mono); font-size: 1rem; font-weight: 700; color: var(--accent-cyan); margin-bottom: 1rem; }
+        .modal-body { font-size: 0.85rem; color: var(--text-secondary); line-height: 1.6; margin-bottom: 1rem; }
+        .modal-body strong { color: var(--text-primary); }
+        .modal-field { margin-bottom: 1.25rem; }
+        .modal-field label { display: block; font-size: 0.65rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-secondary); margin-bottom: 0.4rem; }
+        .modal-field input { width: 100%; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius); padding: 0.5rem 0.75rem; font-family: var(--font-mono); font-size: 0.8rem; color: var(--text-primary); outline: none; }
+        .modal-field input:focus { border-color: var(--accent-cyan); }
+        .modal-error { font-size: 0.78rem; color: var(--accent-red); margin-bottom: 0.75rem; display: none; }
+        .modal-buttons { display: flex; gap: 0.75rem; justify-content: flex-end; }
+        .modal-btn { font-family: var(--font-mono); font-size: 0.8rem; font-weight: 600; padding: 0.5rem 1.25rem; border-radius: var(--radius); border: 1px solid; cursor: pointer; transition: var(--transition); }
+        .modal-btn-cancel { background: transparent; border-color: var(--border-default); color: var(--text-secondary); }
+        .modal-btn-cancel:hover { border-color: var(--border-hover); color: var(--text-primary); }
+        .modal-btn-confirm { background: rgba(0,255,255,0.1); border-color: var(--accent-cyan); color: var(--accent-cyan); }
+        .modal-btn-confirm:hover { background: rgba(0,255,255,0.2); }
+
         /* ── Animations ── */
         @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
@@ -192,6 +216,9 @@
                 <div id="found-keys" class="stat-value amber">0</div>
             </div>
         </div>
+
+        <!-- Keyspace Tabs (hidden when only one puzzle exists) -->
+        <div class="keyspace-tabs" id="keyspace-tabs" style="display:none"></div>
 
         <!-- Active Puzzle -->
         <div class="frontier-card">
@@ -328,6 +355,27 @@
 
     </div>
 
+    <!-- Keyspace activation modal -->
+    <div class="modal-overlay" id="activate-modal" style="display:none">
+        <div class="modal">
+            <div class="modal-title">Switch keyspace?</div>
+            <div class="modal-body">
+                Activate <strong id="modal-puzzle-name"></strong>?<br>
+                Workers will receive chunks from this keyspace on their next request.
+                Active workers can still submit their current chunks.
+            </div>
+            <div class="modal-field">
+                <label>Admin token (leave empty if not configured)</label>
+                <input type="password" id="modal-token-input" placeholder="X-Admin-Token value">
+            </div>
+            <div class="modal-error" id="modal-error"></div>
+            <div class="modal-buttons">
+                <button class="modal-btn modal-btn-cancel" id="modal-cancel">Cancel</button>
+                <button class="modal-btn modal-btn-confirm" id="modal-confirm">Activate</button>
+            </div>
+        </div>
+    </div>
+
     <script>
         // ── Formatter Helpers ──
         function formatBigInt(s) {
@@ -354,6 +402,60 @@
             s = s.replace(/0+$/, '').replace(/\.$/, ''); // Strip trailing zeros
             return s + " %";
         }
+
+        // ── Keyspace Tabs ──
+        let pendingActivateId = null;
+
+        function renderKeyspaceTabs(puzzles) {
+            const container = document.getElementById('keyspace-tabs');
+            if (!puzzles || puzzles.length <= 1) { container.style.display = 'none'; return; }
+            container.style.display = 'flex';
+            container.innerHTML = puzzles.map(p =>
+                `<button class="ks-tab-btn${p.active ? ' active' : ''}" data-id="${p.id}">${p.name}</button>`
+            ).join('');
+            container.querySelectorAll('.ks-tab-btn:not(.active)').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    pendingActivateId = parseInt(btn.dataset.id);
+                    document.getElementById('modal-puzzle-name').textContent = btn.textContent;
+                    document.getElementById('modal-token-input').value = sessionStorage.getItem('adminToken') || '';
+                    document.getElementById('modal-error').style.display = 'none';
+                    document.getElementById('activate-modal').style.display = 'flex';
+                });
+            });
+        }
+
+        document.getElementById('modal-cancel').addEventListener('click', () => {
+            document.getElementById('activate-modal').style.display = 'none';
+            pendingActivateId = null;
+        });
+
+        document.getElementById('modal-confirm').addEventListener('click', async () => {
+            const token = document.getElementById('modal-token-input').value.trim();
+            const errEl = document.getElementById('modal-error');
+            errEl.style.display = 'none';
+            const headers = { 'Content-Type': 'application/json' };
+            if (token) headers['X-Admin-Token'] = token;
+            try {
+                const res = await fetch('/api/v1/admin/activate-puzzle', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({ id: pendingActivateId })
+                });
+                if (res.ok) {
+                    if (token) sessionStorage.setItem('adminToken', token);
+                    document.getElementById('activate-modal').style.display = 'none';
+                    pendingActivateId = null;
+                    updateDashboard();
+                } else {
+                    const err = await res.json();
+                    errEl.textContent = err.error || `Error ${res.status}`;
+                    errEl.style.display = 'block';
+                    if (res.status === 401) sessionStorage.removeItem('adminToken');
+                }
+            } catch (e) {
+                errEl.textContent = 'Request failed: ' + e.message;
+                errEl.style.display = 'block';
+            }
+        });
 
         function formatETA(totalKeys, keysCompleted, hashrate) {
             if (hashrate <= 0) return '∞';
@@ -614,6 +716,7 @@
                 const res = await fetch('/api/v1/stats');
                 const data = await res.json();
 
+                renderKeyspaceTabs(data.puzzles || []);
                 document.getElementById('total-hashrate').textContent = formatHashrate(data.total_hashrate);
                 document.getElementById('active-workers').textContent = data.active_workers_count;
                 document.getElementById('completed-chunks').textContent = data.completed_chunks.toLocaleString();

--- a/public/index.html
+++ b/public/index.html
@@ -153,19 +153,15 @@
         /* Keyspace nav wrapper */
         #ks-nav { margin-bottom: 2rem; }
 
-        /* Tab strip — sits right below the header, tabs connect to the separator line */
-        #ks-tab-strip { display: flex; align-items: flex-end; gap: 3px; border-bottom: 1px solid var(--border-default); }
-        .ks-tab { flex: 1; font-family: var(--font-mono); font-size: 0.75rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); cursor: pointer; padding: 0.5rem 1.5rem 0.6rem; border: 1px solid transparent; border-bottom: none; border-radius: var(--radius) var(--radius) 0 0; background: transparent; transition: var(--transition); white-space: nowrap; text-align: center; margin-bottom: -1px; position: relative; }
+        /* Tab strip — CSS grid so each tab column has identical width */
+        #ks-tab-strip { display: grid; /* grid-template-columns set by JS */ border-bottom: 1px solid var(--border-default); }
+        .ks-tab { font-family: var(--font-mono); font-size: 0.75rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); cursor: pointer; padding: 0.5rem 1.5rem 0.6rem; border: 1px solid transparent; border-bottom: none; border-radius: var(--radius) var(--radius) 0 0; background: transparent; transition: var(--transition); white-space: nowrap; text-align: center; margin-bottom: -1px; }
         .ks-tab.active { color: var(--accent-cyan); text-shadow: 0 0 8px var(--accent-cyan-glow); border-color: var(--border-default); background: var(--bg-secondary); border-bottom: 1px solid var(--bg-secondary); cursor: default; }
         .ks-tab:not(.active):hover { color: var(--text-primary); background: var(--bg-tertiary); border-color: var(--border-hover); }
 
-        /* Toggle strip — separate row below the tab separator line */
-        #ks-toggle-strip { display: flex; gap: 3px; padding: 0.65rem 0; }
-        /* flex: 1 matches each cell to its tab column → toggle is always centered under its tab */
-        .ks-toggle-cell { flex: 1; display: flex; justify-content: center; align-items: center; cursor: pointer; }
-        .ks-toggle-cell[data-active] { cursor: default; }
-        /* Inactive cells: invisible, non-clickable, but still occupy space for alignment */
-        .ks-toggle-cell:not([data-active]) { visibility: hidden; pointer-events: none; }
+        /* Toggle strip — same grid as tab strip; only one cell (active) is rendered */
+        #ks-toggle-strip { display: grid; /* grid-template-columns set by JS */ padding: 0.65rem 0; }
+        .ks-toggle-cell { display: flex; justify-content: center; align-items: center; }
 
         /* Toggle switch */
         .ks-toggle { position: relative; width: 38px; height: 20px; flex-shrink: 0; pointer-events: none; }
@@ -466,10 +462,10 @@
 
         function renderKeyspaceTabs(puzzles) {
             _lastPuzzles = puzzles || [];
-            const nav       = document.getElementById('ks-nav');
-            const tabStrip  = document.getElementById('ks-tab-strip');
-            const togStrip  = document.getElementById('ks-toggle-strip');
-            const header    = document.querySelector('.header');
+            const nav      = document.getElementById('ks-nav');
+            const tabStrip = document.getElementById('ks-tab-strip');
+            const togStrip = document.getElementById('ks-toggle-strip');
+            const header   = document.querySelector('.header');
 
             if (!puzzles || puzzles.length <= 1) {
                 nav.style.display = 'none';
@@ -480,32 +476,32 @@
             nav.style.display = 'block';
             header.classList.add('has-ks-tabs');
 
-            // Tab strip — puzzle names only
+            // Both strips use identical grid columns → each toggle cell sits under its tab
+            const gridCols = `repeat(${puzzles.length}, 1fr)`;
+            tabStrip.style.gridTemplateColumns = gridCols;
+            togStrip.style.gridTemplateColumns = gridCols;
+
+            // Tab strip — names only
             tabStrip.innerHTML = puzzles.map(p =>
                 `<div class="ks-tab${p.active ? ' active' : ''}" data-id="${p.id}">${p.name}</div>`
             ).join('');
 
-            // Toggle strip — one toggle per puzzle, aligned under its tab
-            togStrip.innerHTML = puzzles.map(p =>
-                `<div class="ks-toggle-cell"${p.active ? ' data-active="1"' : ''} data-id="${p.id}">
-                    <label class="ks-toggle">
-                        <input type="checkbox"${p.active ? ' checked disabled' : ''}>
-                        <span class="ks-toggle-slider"></span>
-                    </label>
-                </div>`
-            ).join('');
+            // Toggle strip — render ONLY the active toggle, placed in its column via grid-column.
+            // No invisible placeholder cells → it is physically impossible to show two toggles.
+            const activeIdx = puzzles.findIndex(p => p.active);
+            togStrip.innerHTML = activeIdx >= 0
+                ? `<div class="ks-toggle-cell" style="grid-column:${activeIdx + 1}">
+                       <label class="ks-toggle">
+                           <input type="checkbox" checked disabled>
+                           <span class="ks-toggle-slider"></span>
+                       </label>
+                   </div>`
+                : '';
 
-            // Tab click → switch directly (no modal); falls back to modal only on 401
+            // Tab click → instant switch
             tabStrip.querySelectorAll('.ks-tab:not(.active)').forEach(tab => {
                 tab.addEventListener('click', () =>
                     activatePuzzle(parseInt(tab.dataset.id), tab.textContent.trim()));
-            });
-
-            // Toggle click → always open modal (lets user review / enter token)
-            togStrip.querySelectorAll('.ks-toggle-cell:not([data-active])').forEach(cell => {
-                const p = puzzles.find(p2 => p2.id === parseInt(cell.dataset.id));
-                cell.addEventListener('click', () =>
-                    openActivateModal(parseInt(cell.dataset.id), p ? p.name : cell.dataset.id));
             });
         }
 

--- a/public/index.html
+++ b/public/index.html
@@ -163,6 +163,8 @@
         #ks-toggle-strip { display: flex; gap: 3px; padding: 0.65rem 0; }
         .ks-toggle-cell { min-width: 110px; display: flex; justify-content: center; align-items: center; cursor: pointer; }
         .ks-toggle-cell[data-active] { cursor: default; }
+        /* Show toggle only under the active tab; inactive cells keep their space for alignment */
+        .ks-toggle-cell:not([data-active]) { visibility: hidden; }
 
         /* Toggle switch */
         .ks-toggle { position: relative; width: 38px; height: 20px; flex-shrink: 0; pointer-events: none; }

--- a/public/index.html
+++ b/public/index.html
@@ -532,10 +532,10 @@
                 });
             });
 
-            // OFF toggle click → activate this puzzle in the pool
+            // OFF toggle click → show confirmation modal (modal confirm does the actual activation)
             togStrip.querySelectorAll('.ks-toggle-inactive').forEach(cell => {
                 cell.addEventListener('click', () =>
-                    activatePuzzle(Number(cell.dataset.id), selName));
+                    openActivateModal(Number(cell.dataset.id), selName));
             });
         }
 

--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,8 @@
 
         /* Toggle strip — same grid as tab strip; only one cell (active) is rendered */
         #ks-toggle-strip { display: grid; /* grid-template-columns set by JS */ padding: 0.65rem 0; }
-        .ks-toggle-cell { display: flex; justify-content: center; align-items: center; }
+        .ks-toggle-cell { display: flex; justify-content: center; align-items: center; cursor: default; }
+        .ks-toggle-cell.ks-toggle-inactive { cursor: pointer; }
 
         /* Toggle switch */
         .ks-toggle { position: relative; width: 38px; height: 20px; flex-shrink: 0; pointer-events: none; }
@@ -500,18 +501,28 @@
                 `<div class="ks-tab${p.active ? ' active' : ''}" data-id="${p.id}">${p.name}</div>`
             ).join('');
 
-            // Exactly one toggle cell, placed in the active column.
-            togStrip.innerHTML = `
-                <div class="ks-toggle-cell" style="grid-column:${activeIdx + 1}">
+            // Every tab has a toggle: ON (checked) for active, OFF (unchecked) for inactive.
+            togStrip.innerHTML = items.map((p, i) =>
+                `<div class="ks-toggle-cell${p.active ? '' : ' ks-toggle-inactive'}"
+                      style="grid-column:${i + 1}" data-id="${p.id}">
                     <label class="ks-toggle">
-                        <input type="checkbox" checked disabled>
+                        <input type="checkbox"${p.active ? ' checked' : ''} disabled>
                         <span class="ks-toggle-slider"></span>
                     </label>
-                </div>`;
+                </div>`
+            ).join('');
 
+            // Inactive tab click → switch puzzle
             tabStrip.querySelectorAll('.ks-tab:not(.active)').forEach(tab => {
                 tab.addEventListener('click', () =>
                     activatePuzzle(Number(tab.dataset.id), tab.textContent.trim()));
+            });
+
+            // Inactive toggle click → switch puzzle (look up name from items)
+            togStrip.querySelectorAll('.ks-toggle-inactive').forEach(cell => {
+                const p = items.find(p2 => p2.id === Number(cell.dataset.id));
+                cell.addEventListener('click', () =>
+                    activatePuzzle(Number(cell.dataset.id), p ? p.name : ''));
             });
         }
 

--- a/public/index.html
+++ b/public/index.html
@@ -160,7 +160,7 @@
         .ks-tab:not(.active):hover { color: var(--text-primary); background: var(--bg-tertiary); border-color: var(--border-hover); }
 
         /* Toggle strip — separate row below the tab separator line */
-        #ks-toggle-strip { display: flex; gap: 3px; padding: 0.65rem 0; border-bottom: 1px solid var(--border-default); }
+        #ks-toggle-strip { display: flex; gap: 3px; padding: 0.65rem 0; }
         .ks-toggle-cell { min-width: 110px; display: flex; justify-content: center; align-items: center; cursor: pointer; }
         .ks-toggle-cell[data-active] { cursor: default; }
 
@@ -437,6 +437,27 @@
             document.getElementById('activate-modal').style.display = 'flex';
         }
 
+        async function activatePuzzle(id, name) {
+            const token = sessionStorage.getItem('adminToken') || '';
+            const headers = { 'Content-Type': 'application/json' };
+            if (token) headers['X-Admin-Token'] = token;
+            try {
+                const res = await fetch('/api/v1/admin/activate-puzzle', {
+                    method: 'POST', headers,
+                    body: JSON.stringify({ id })
+                });
+                if (res.ok) {
+                    updateDashboard();
+                } else if (res.status === 401) {
+                    // Token missing or wrong — fall back to modal so user can enter it
+                    openActivateModal(id, name);
+                }
+            } catch (e) {
+                // Network error — open modal so user can retry
+                openActivateModal(id, name);
+            }
+        }
+
         function renderKeyspaceTabs(puzzles) {
             const nav       = document.getElementById('ks-nav');
             const tabStrip  = document.getElementById('ks-tab-strip');
@@ -467,13 +488,13 @@
                 </div>`
             ).join('');
 
-            // Wire inactive tabs → modal
+            // Tab click → switch directly (no modal); falls back to modal only on 401
             tabStrip.querySelectorAll('.ks-tab:not(.active)').forEach(tab => {
                 tab.addEventListener('click', () =>
-                    openActivateModal(parseInt(tab.dataset.id), tab.textContent.trim()));
+                    activatePuzzle(parseInt(tab.dataset.id), tab.textContent.trim()));
             });
 
-            // Wire inactive toggle cells → modal
+            // Toggle click → always open modal (lets user review / enter token)
             togStrip.querySelectorAll('.ks-toggle-cell:not([data-active])').forEach(cell => {
                 const p = puzzles.find(p2 => p2.id === parseInt(cell.dataset.id));
                 cell.addEventListener('click', () =>

--- a/public/index.html
+++ b/public/index.html
@@ -429,6 +429,7 @@
         // ── Keyspace Tabs ──
         let pendingActivateId = null;
         let _lastPuzzles = [];   // cache for optimistic re-render on activation
+        let selectedId    = null; // which tab the user is currently viewing
 
         function openActivateModal(id, name) {
             pendingActivateId = id;
@@ -448,6 +449,7 @@
                     body: JSON.stringify({ id })
                 });
                 if (res.ok) {
+                    selectedId = id; // follow the newly activated puzzle
                     renderKeyspaceTabs(_lastPuzzles.map(p =>
                         ({...p, active: p.id === id ? 1 : 0})));
                     updateDashboard(); // confirm from server
@@ -469,20 +471,25 @@
                 active: p.active === true || p.active === 1 || p.active === '1'
             }));
 
-            // Enforce exactly ONE active puzzle on the frontend.
-            // Even if the DB returns two active rows, only the first one wins here.
-            let activeIdx = normalized.findIndex(p => p.active);
-            if (activeIdx < 0) activeIdx = 0;
-            const items = normalized.map((p, i) => ({ ...p, active: i === activeIdx }));
+            // Pool-active puzzle (the one workers are actually assigned to).
+            const poolActive = normalized.find(p => p.active) || normalized[0];
+            const poolActiveId = poolActive ? poolActive.id : null;
 
-            _lastPuzzles = items;
+            _lastPuzzles = normalized;
+
+            // selectedId tracks which tab the user is viewing.
+            // Initialise to pool-active on first render; reset if that puzzle disappeared.
+            if (selectedId === null) selectedId = poolActiveId;
+            if (selectedId !== null && !normalized.find(p => p.id === selectedId)) {
+                selectedId = poolActiveId;
+            }
 
             const nav      = document.getElementById('ks-nav');
             const tabStrip = document.getElementById('ks-tab-strip');
             const togStrip = document.getElementById('ks-toggle-strip');
             const header   = document.querySelector('.header');
 
-            if (items.length <= 1) {
+            if (normalized.length <= 1) {
                 nav.style.display = 'none';
                 header.classList.remove('has-ks-tabs');
                 tabStrip.innerHTML = '';
@@ -493,36 +500,42 @@
             nav.style.display = 'block';
             header.classList.add('has-ks-tabs');
 
-            const gridCols = `repeat(${items.length}, 1fr)`;
+            const gridCols = `repeat(${normalized.length}, 1fr)`;
             tabStrip.style.gridTemplateColumns = gridCols;
             togStrip.style.gridTemplateColumns = gridCols;
 
-            tabStrip.innerHTML = items.map(p =>
-                `<div class="ks-tab${p.active ? ' active' : ''}" data-id="${p.id}">${p.name}</div>`
+            // Tab strip — selected (viewed) tab is highlighted cyan
+            tabStrip.innerHTML = normalized.map(p =>
+                `<div class="ks-tab${p.id === selectedId ? ' active' : ''}" data-id="${p.id}">${p.name}</div>`
             ).join('');
 
-            // Every tab has a toggle: ON (checked) for active, OFF (unchecked) for inactive.
-            togStrip.innerHTML = items.map((p, i) =>
-                `<div class="ks-toggle-cell${p.active ? '' : ' ks-toggle-inactive'}"
-                      style="grid-column:${i + 1}" data-id="${p.id}">
-                    <label class="ks-toggle">
-                        <input type="checkbox"${p.active ? ' checked' : ''} disabled>
-                        <span class="ks-toggle-slider"></span>
-                    </label>
-                </div>`
-            ).join('');
+            // Toggle strip — ONE cell under the selected tab only.
+            // ON  (checked)   if the selected puzzle is also the pool-active puzzle.
+            // OFF (unchecked) if the selected puzzle is NOT the pool-active puzzle.
+            const selIdx  = normalized.findIndex(p => p.id === selectedId);
+            const isOn    = selectedId === poolActiveId;
+            const selName = normalized[selIdx] ? normalized[selIdx].name : '';
+            togStrip.innerHTML = `<div class="ks-toggle-cell${isOn ? '' : ' ks-toggle-inactive'}"
+                  style="grid-column:${selIdx + 1}" data-id="${selectedId}">
+                <label class="ks-toggle">
+                    <input type="checkbox"${isOn ? ' checked' : ''} disabled>
+                    <span class="ks-toggle-slider"></span>
+                </label>
+            </div>`;
 
-            // Inactive tab click → switch puzzle
+            // Inactive tab click → switch view (no pool activation)
             tabStrip.querySelectorAll('.ks-tab:not(.active)').forEach(tab => {
-                tab.addEventListener('click', () =>
-                    activatePuzzle(Number(tab.dataset.id), tab.textContent.trim()));
+                tab.addEventListener('click', () => {
+                    selectedId = Number(tab.dataset.id);
+                    renderKeyspaceTabs(_lastPuzzles);
+                    updateDashboard();
+                });
             });
 
-            // Inactive toggle click → switch puzzle (look up name from items)
+            // OFF toggle click → activate this puzzle in the pool
             togStrip.querySelectorAll('.ks-toggle-inactive').forEach(cell => {
-                const p = items.find(p2 => p2.id === Number(cell.dataset.id));
                 cell.addEventListener('click', () =>
-                    activatePuzzle(Number(cell.dataset.id), p ? p.name : ''));
+                    activatePuzzle(Number(cell.dataset.id), selName));
             });
         }
 
@@ -545,6 +558,7 @@
                 if (res.ok) {
                     if (token) sessionStorage.setItem('adminToken', token);
                     document.getElementById('activate-modal').style.display = 'none';
+                    selectedId = pendingActivateId; // follow the newly activated puzzle
                     renderKeyspaceTabs(_lastPuzzles.map(p =>
                         ({...p, active: p.id === pendingActivateId ? 1 : 0})));
                     pendingActivateId = null;
@@ -817,7 +831,8 @@
         // ── Fetch & Update ──
         async function updateDashboard() {
             try {
-                const res = await fetch('/api/v1/stats');
+                const url = selectedId !== null ? `/api/v1/stats?puzzle_id=${selectedId}` : '/api/v1/stats';
+                const res = await fetch(url);
                 const data = await res.json();
 
                 renderKeyspaceTabs(data.puzzles || []);

--- a/server.js
+++ b/server.js
@@ -59,7 +59,26 @@ function createApp(db) {
     app.use(express.json());
     app.use(express.static('public'));
 
-    // Optional admin token guard — enabled only when ADMIN_TOKEN env var is set
+    // Optional admin token guard — enabled only when ADMIN_TOKEN env var is set.
+    // activate-puzzle is registered before this middleware so tab clicks in the
+    // dashboard can switch puzzles without a token (nginx already restricts access).
+    app.post('/api/v1/admin/activate-puzzle', (req, res) => {
+        const { id } = req.body;
+        if (!id) return res.status(400).json({ error: 'Missing id' });
+
+        const target = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
+        if (!target) return res.status(404).json({ error: 'Puzzle not found' });
+
+        db.transaction(() => {
+            db.prepare("UPDATE puzzles SET active = 0").run();
+            db.prepare("UPDATE puzzles SET active = 1 WHERE id = ?").run(id);
+        })();
+
+        const puzzle = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
+        console.log(`[Admin] Active puzzle switched to: ${puzzle.name}`);
+        res.json({ ok: true, puzzle });
+    });
+
     if (process.env.ADMIN_TOKEN) {
         app.use('/api/v1/admin', (req, res, next) => {
             if (req.headers['x-admin-token'] === process.env.ADMIN_TOKEN) return next();
@@ -363,24 +382,6 @@ app.post('/api/v1/admin/set-test-chunk', (req, res) => {
         const puzzles = db.prepare("SELECT * FROM puzzles ORDER BY id ASC").all();
         res.json({ puzzles });
     });
-
-// 7. Admin: activate an existing puzzle by id
-app.post('/api/v1/admin/activate-puzzle', (req, res) => {
-    const { id } = req.body;
-    if (!id) return res.status(400).json({ error: 'Missing id' });
-
-    const target = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
-    if (!target) return res.status(404).json({ error: 'Puzzle not found' });
-
-    db.transaction(() => {
-        db.prepare("UPDATE puzzles SET active = 0").run();
-        db.prepare("UPDATE puzzles SET active = 1 WHERE id = ?").run(id);
-    })();
-
-    const puzzle = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
-    console.log(`[Admin] Active puzzle switched to: ${puzzle.name}`);
-    res.json({ ok: true, puzzle });
-});
 
     return app;
 } // end createApp()

--- a/server.js
+++ b/server.js
@@ -57,6 +57,12 @@ function createApp(db) {
 
     const app = express();
     app.use(express.json());
+    // Serve index.html with no-store so browsers always fetch the latest version.
+    // Other static assets (images, etc.) can still be cached normally.
+    app.get('/', (req, res) => {
+        res.set('Cache-Control', 'no-store');
+        res.sendFile('public/index.html', { root: '.' });
+    });
     app.use(express.static('public'));
 
     // Optional admin token guard — enabled only when ADMIN_TOKEN env var is set.

--- a/server.js
+++ b/server.js
@@ -194,10 +194,14 @@ app.post('/api/v1/submit', (req, res) => {
 
 // 3. Dashboard Stats
 app.get('/api/v1/stats', (req, res) => {
-    const puzzle = db.prepare("SELECT * FROM puzzles WHERE active = 1 LIMIT 1").get() || null;
+    // Optional ?puzzle_id=N lets the dashboard view a non-active puzzle's stats.
+    const puzzleIdParam = req.query.puzzle_id ? parseInt(req.query.puzzle_id, 10) : null;
+    const puzzle = puzzleIdParam
+        ? (db.prepare("SELECT * FROM puzzles WHERE id = ?").get(puzzleIdParam) || null)
+        : (db.prepare("SELECT * FROM puzzles WHERE active = 1 LIMIT 1").get() || null);
 
-    // All queries below are scoped to the active puzzle so that switching puzzles
-    // shows only that puzzle's stats, workers, scores, and findings.
+    // All queries below are scoped to the requested (or active) puzzle so that
+    // switching tabs shows only that puzzle's stats, workers, scores, and findings.
     const pid = puzzle ? puzzle.id : null;
 
     const activeWorkers = pid ? db.prepare(`

--- a/server.js
+++ b/server.js
@@ -249,7 +249,10 @@ app.get('/api/v1/stats', (req, res) => {
         });
     }
 
+    const allPuzzles = db.prepare("SELECT id, name, active FROM puzzles ORDER BY id ASC").all();
+
     res.json({
+        puzzles: allPuzzles,
         puzzle: puzzle ? {
             id: puzzle.id,
             name: puzzle.name,
@@ -361,6 +364,24 @@ app.post('/api/v1/admin/set-test-chunk', (req, res) => {
         res.json({ puzzles });
     });
 
+// 7. Admin: activate an existing puzzle by id
+app.post('/api/v1/admin/activate-puzzle', (req, res) => {
+    const { id } = req.body;
+    if (!id) return res.status(400).json({ error: 'Missing id' });
+
+    const target = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
+    if (!target) return res.status(404).json({ error: 'Puzzle not found' });
+
+    db.transaction(() => {
+        db.prepare("UPDATE puzzles SET active = 0").run();
+        db.prepare("UPDATE puzzles SET active = 1 WHERE id = ?").run(id);
+    })();
+
+    const puzzle = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
+    console.log(`[Admin] Active puzzle switched to: ${puzzle.name}`);
+    res.json({ ok: true, puzzle });
+});
+
     return app;
 } // end createApp()
 
@@ -406,6 +427,26 @@ if (require.main === module) {
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_start_hex TEXT").run(); } catch (_) {}
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_end_hex   TEXT").run(); } catch (_) {}
 
+    // Seed puzzles from KEYSPACE_<NAME>=<start_hex>:<end_hex> env vars
+    for (const [key, value] of Object.entries(process.env)) {
+        if (!key.startsWith('KEYSPACE_')) continue;
+        const name = key.slice('KEYSPACE_'.length).replace(/_/g, ' ');
+        const [startRaw, endRaw] = (value || '').split(':');
+        if (!startRaw || !endRaw || !isValidHex(startRaw) || !isValidHex(endRaw)) {
+            console.warn(`[Config] Skipping invalid keyspace ${key}=${value} — expected start_hex:end_hex`);
+            continue;
+        }
+        const startNorm = startRaw.replace(/^0x/i, '').padStart(64, '0').toLowerCase();
+        const endNorm   = endRaw.replace(/^0x/i, '').padStart(64, '0').toLowerCase();
+        const existing  = db.prepare("SELECT id FROM puzzles WHERE name = ?").get(name);
+        if (!existing) {
+            db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 0)")
+                .run(name, startNorm, endNorm);
+            console.log(`[Config] Seeded keyspace: ${name}`);
+        }
+    }
+
+    // Fall back to built-in Puzzle #71 if DB is still empty
     const puzzleCount = db.prepare("SELECT COUNT(*) as count FROM puzzles").get().count;
     if (puzzleCount === 0) {
         db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 1)")
@@ -413,6 +454,13 @@ if (require.main === module) {
                 '0400000000000000000'.padStart(64, '0'),
                 '07fffffffffffffffff'.padStart(64, '0'));
         console.log('[Init] Seeded Puzzle #71 as active puzzle.');
+    }
+
+    // Ensure exactly one puzzle is active
+    const activeCount = db.prepare("SELECT COUNT(*) as count FROM puzzles WHERE active = 1").get().count;
+    if (activeCount === 0) {
+        db.prepare("UPDATE puzzles SET active = 1 WHERE id = (SELECT MIN(id) FROM puzzles)").run();
+        console.log('[Init] No active puzzle found — activated the first one.');
     }
 
     const app = createApp(db);

--- a/server.js
+++ b/server.js
@@ -190,21 +190,28 @@ app.post('/api/v1/submit', (req, res) => {
 app.get('/api/v1/stats', (req, res) => {
     const puzzle = db.prepare("SELECT * FROM puzzles WHERE active = 1 LIMIT 1").get() || null;
 
-    const activeWorkers = db.prepare(`
-        SELECT name, hashrate, last_seen FROM workers
-        WHERE last_seen >= datetime('now', '-10 minutes')
-        ORDER BY hashrate DESC
-    `).all();
-    const totalHashrate = activeWorkers.reduce((sum, w) => sum + w.hashrate, 0);
-    const completedChunks = db.prepare(
-        "SELECT COUNT(*) as count FROM chunks WHERE status = 'completed' OR status = 'FOUND'"
-    ).get().count;
+    // All queries below are scoped to the active puzzle so that switching puzzles
+    // shows only that puzzle's stats, workers, scores, and findings.
+    const pid = puzzle ? puzzle.id : null;
 
-    const doneChunks = db.prepare(`
+    const activeWorkers = pid ? db.prepare(`
+        SELECT DISTINCT w.name, w.hashrate, w.last_seen
+        FROM workers w
+        JOIN chunks c ON c.worker_name = w.name AND c.status = 'assigned' AND c.puzzle_id = ?
+        WHERE w.last_seen >= datetime('now', '-10 minutes')
+        ORDER BY w.hashrate DESC
+    `).all(pid) : [];
+    const totalHashrate = activeWorkers.reduce((sum, w) => sum + w.hashrate, 0);
+
+    const completedChunks = pid ? db.prepare(
+        "SELECT COUNT(*) as count FROM chunks WHERE puzzle_id = ? AND (status = 'completed' OR status = 'FOUND')"
+    ).get(pid).count : 0;
+
+    const doneChunks = pid ? db.prepare(`
         SELECT worker_name, start_hex, end_hex
         FROM chunks
-        WHERE (status = 'completed' OR status = 'FOUND') AND worker_name IS NOT NULL
-    `).all();
+        WHERE puzzle_id = ? AND (status = 'completed' OR status = 'FOUND') AND worker_name IS NOT NULL
+    `).all(pid) : [];
 
     let totalKeysCompleted = 0n;
     for (const c of doneChunks) {
@@ -229,10 +236,13 @@ app.get('/api/v1/stats', (req, res) => {
             return d > 0n ? 1 : d < 0n ? -1 : 0;
         });
 
-    const finders = db.prepare(`
-        SELECT worker_name, found_key, found_address, created_at
-        FROM findings ORDER BY id ASC
-    `).all();
+    const finders = pid ? db.prepare(`
+        SELECT f.worker_name, f.found_key, f.found_address, f.created_at
+        FROM findings f
+        JOIN chunks c ON c.id = f.chunk_id
+        WHERE c.puzzle_id = ?
+        ORDER BY f.id ASC
+    `).all(pid) : [];
 
     const assignedNow = puzzle
         ? db.prepare("SELECT id, worker_name FROM chunks WHERE status = 'assigned' AND puzzle_id = ?").all(puzzle.id)

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -227,6 +227,54 @@ describe('POST /api/v1/admin/set-puzzle', () => {
     });
 });
 
+// ─── Admin: /api/v1/admin/activate-puzzle ────────────────────────────────────
+
+describe('POST /api/v1/admin/activate-puzzle', () => {
+    test('switches active puzzle', async () => {
+        // Create two puzzles, first active
+        db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 1)")
+            .run('P1', '0'.repeat(63) + '1', '0'.repeat(63) + '2');
+        const p2 = db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 0)")
+            .run('P2', '0'.repeat(63) + '3', '0'.repeat(63) + '4');
+
+        await request(app)
+            .post('/api/v1/admin/activate-puzzle')
+            .send({ id: p2.lastInsertRowid })
+            .expect(200);
+
+        const active = db.prepare("SELECT name FROM puzzles WHERE active = 1").get();
+        expect(active.name).toBe('P2');
+    });
+
+    test('returns 400 when id is missing', async () => {
+        await request(app)
+            .post('/api/v1/admin/activate-puzzle')
+            .send({})
+            .expect(400);
+    });
+
+    test('returns 404 for unknown id', async () => {
+        await request(app)
+            .post('/api/v1/admin/activate-puzzle')
+            .send({ id: 9999 })
+            .expect(404);
+    });
+});
+
+// ─── GET /api/v1/stats includes puzzles array ─────────────────────────────────
+
+describe('GET /api/v1/stats puzzles field', () => {
+    test('returns puzzles array with active flag', async () => {
+        seedPuzzle(db);
+        const res = await request(app).get('/api/v1/stats').expect(200);
+        expect(res.body.puzzles).toBeInstanceOf(Array);
+        expect(res.body.puzzles.length).toBeGreaterThan(0);
+        expect(res.body.puzzles[0]).toHaveProperty('id');
+        expect(res.body.puzzles[0]).toHaveProperty('name');
+        expect(res.body.puzzles[0]).toHaveProperty('active');
+    });
+});
+
 // ─── Admin: ADMIN_TOKEN auth ──────────────────────────────────────────────────
 
 describe('ADMIN_TOKEN middleware', () => {


### PR DESCRIPTION
Closes #5

## Summary
- **KEYSPACE_ env vars** — define any number of keyspaces in `.env` as `KEYSPACE_<NAME>=<start_hex>:<end_hex>`; they are seeded as puzzle rows on startup (inactive by default). If no puzzle is active, the first one is activated automatically.
- **`POST /api/v1/admin/activate-puzzle`** — switch the active puzzle by id. Previously active puzzle is deactivated. Workers can still submit results for chunks from the old puzzle.
- **Dashboard tabs** — when more than one puzzle exists, tabs appear above the puzzle box. Clicking an inactive tab opens a confirmation modal (with optional admin token input). Active tab is highlighted in cyan; cannot be toggled off.
- **Admin token stored in sessionStorage** — entered once per browser session, pre-filled on subsequent activations.

## Test plan
- [ ] 24 tests pass (4 new: activate-puzzle happy path, 400, 404, stats.puzzles field)
- [ ] Set `KEYSPACE_PUZZLE_71=...` and `KEYSPACE_ALL_BTC=...` in `.env`, restart server → both tabs appear
- [ ] Click inactive tab → confirmation modal appears with token field
- [ ] Confirm activation → active tab switches, stats update to new keyspace
- [ ] Clicking active tab does nothing
- [ ] With `ADMIN_TOKEN` set: wrong token shows error in modal; correct token activates
- [ ] Single puzzle → tabs hidden