### PR TITLE
fix: dashboard display fixes for large keyspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ See [docs/api.md](docs/api.md) for full request/response schemas.
 | `POST` | `/api/v1/heartbeat` | Reset reclaim timer for long jobs |
 | `GET`  | `/api/v1/stats` | Dashboard data |
 | `POST` | `/api/v1/admin/set-puzzle` | Create / activate a puzzle |
+| `POST` | `/api/v1/admin/activate-puzzle` | Switch the active puzzle by ID |
 | `POST` | `/api/v1/admin/set-test-chunk` | Set verification chunk for new workers |
 | `GET`  | `/api/v1/admin/puzzles` | List all puzzles |
 
@@ -102,6 +103,7 @@ cp .env.example .env
 | `TARGET_MINUTES` | `5` | Expected time to complete one chunk |
 | `TIMEOUT_MINUTES` | `15` | Minutes before an inactive chunk is reclaimed |
 | `ADMIN_TOKEN` | *(unset)* | If set, admin routes require `X-Admin-Token` header |
+| `KEYSPACE_<NAME>` | *(unset)* | Seed a keyspace on startup: `KEYSPACE_ALL_BTC=<start_hex>:<end_hex>`. Underscores in the variable name become spaces in the puzzle name. Multiple variables are supported. |
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -99,6 +99,12 @@ Call every 60–120 seconds while scanning a large chunk.
 
 Dashboard data — polled every 3 seconds by `index.html`.
 
+**Query parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `puzzle_id` | number | *(optional)* Return stats for this puzzle ID instead of the pool-active one. Used by the dashboard when the user views a non-active tab. |
+
 **Response 200** (abbreviated)
 ```json
 {

--- a/public/index.html
+++ b/public/index.html
@@ -863,10 +863,7 @@
                     }
 
                     const eta = formatETA(data.puzzle.total_keys, data.total_keys_completed, data.total_hashrate);
-                    const totalKeysStr = data.puzzle.total_keys.length > 20
-                        ? Number(BigInt(data.puzzle.total_keys)).toExponential(4)
-                        : formatBigInt(data.puzzle.total_keys);
-                    document.getElementById('puzzle-total-keys').textContent = `Keys total: ${totalKeysStr}`;
+                    document.getElementById('puzzle-total-keys').textContent = `Keys total: ${formatBigInt(data.puzzle.total_keys)}`;
                     document.getElementById('puzzle-eta').textContent = `ETA: ${eta}`;
                 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -248,6 +248,7 @@
             <div class="frontier-label" id="puzzle-name">Active Puzzle</div>
             <div id="frontier" class="frontier-value">Loading...</div>
             <div id="puzzle-total-keys" class="stat-subtext"></div>
+            <div id="puzzle-eta" class="stat-subtext"></div>
         </div>
 
         <!-- 1D Keyspace Bar -->
@@ -579,9 +580,12 @@
             if (hashrate <= 0) return '∞';
             const remaining = BigInt(totalKeys) - BigInt(keysCompleted);
             if (remaining <= 0n) return 'Complete';
+            // Use BigInt arithmetic to avoid float overflow on universe-scale keyspaces
+            const remainingYears = remaining / BigInt(Math.round(hashrate * 365.25 * 86400));
+            if (remainingYears > 999_999_999_999n) return '> 1 trillion years';
+            if (remainingYears > 0n) return `~${formatBigInt(remainingYears.toString())} years`;
             const etaSec = Number(remaining) / hashrate;
-            const MINUTE = 60, HOUR = 3600, DAY = 86400, YEAR = 365.25 * DAY;
-            if (etaSec >= YEAR)   return `~${Math.round(etaSec / YEAR)} years`;
+            const MINUTE = 60, HOUR = 3600, DAY = 86400;
             if (etaSec >= DAY)    return `~${Math.round(etaSec / DAY)} days`;
             if (etaSec >= HOUR)   return `~${Math.round(etaSec / HOUR)} hours`;
             if (etaSec >= MINUTE) return `~${Math.round(etaSec / MINUTE)} min`;
@@ -845,7 +849,8 @@
                 // Precision Percentage Calculation & Total Keys Update
                 if (data.puzzle && data.puzzle.total_keys) {
                     document.getElementById('puzzle-name').textContent = data.puzzle.name;
-                    document.getElementById('frontier').textContent = `0x${data.puzzle.start_hex.replace(/^0+/, '')} … 0x${data.puzzle.end_hex.replace(/^0+/, '')}`;
+                    const trimHex = h => { const s = h.replace(/^0+/, '') || '0'; return s.length > 16 ? s.slice(0, 8) + '…' + s.slice(-6) : s; };
+                    document.getElementById('frontier').textContent = `0x${trimHex(data.puzzle.start_hex)} … 0x${trimHex(data.puzzle.end_hex)}`;
                     
                     const totalP = BigInt(data.puzzle.total_keys);
                     const comp = BigInt(data.total_keys_completed);
@@ -858,7 +863,11 @@
                     }
 
                     const eta = formatETA(data.puzzle.total_keys, data.total_keys_completed, data.total_hashrate);
-                    document.getElementById('puzzle-total-keys').textContent = `Keys total: ${formatBigInt(data.puzzle.total_keys)} | ETA: ${eta}`;
+                    const totalKeysStr = data.puzzle.total_keys.length > 20
+                        ? Number(BigInt(data.puzzle.total_keys)).toExponential(4)
+                        : formatBigInt(data.puzzle.total_keys);
+                    document.getElementById('puzzle-total-keys').textContent = `Keys total: ${totalKeysStr}`;
+                    document.getElementById('puzzle-eta').textContent = `ETA: ${eta}`;
                 }
 
                 g_chunks_vis = data.chunks_vis || [];


### PR DESCRIPTION
## Summary

- Truncates long hex ranges in the frontier card (shows first 8 + last 6 chars when > 16 chars)
- ETA moved to its own line below Keys total
- ETA uses BigInt arithmetic to avoid float overflow on universe-scale keyspaces (e.g. ALL BTC), showing `> 1 trillion years` instead of scientific notation
- Keys total stays in dot-separated decimal format
- Docs: added `activate-puzzle`, `?puzzle_id` query param, and `KEYSPACE_<NAME>` env var

## Test plan

- [ ] Deploy: `git pull && sudo systemctl restart puzzpool` (or run `update.sh`)
- [ ] Open dashboard with both Puzzle #71 and ALL BTC tabs
- [ ] Verify ALL BTC frontier shows truncated hex: `0x1 … 0xfffffffe…364141`
- [ ] Verify Keys total shows full decimal number on one line
- [ ] Verify ETA appears on a separate line below Keys total
- [ ] Verify ETA shows `> 1 trillion years` for ALL BTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)