### PR TITLE
feat: STAGE env var with cyan favicon for test instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ TARGET_MINUTES=5
 # Minutes before an unfinished chunk is reclaimed and reissued
 TIMEOUT_MINUTES=15
 
+# Deployment stage — shown in dashboard and used to tint the favicon.
+# Use PROD for production, TEST for the test instance.
+STAGE=PROD
+
 # Admin API token — if set, all /api/v1/admin/* routes require
 # the header:  X-Admin-Token: <value>
 # Leave blank (or unset) to disable auth (suitable for localhost-only deployments

--- a/public/index.html
+++ b/public/index.html
@@ -427,6 +427,17 @@
             return s + " %";
         }
 
+        // ── Stage / Favicon ──
+        let _stageSet = false;
+        function applyStage(stage) {
+            if (_stageSet) return;
+            _stageSet = true;
+            if (stage !== 'TEST') return;
+            // Swap favicon circle from Bitcoin orange (#F7931A) to cyan (#00ffff)
+            const link = document.querySelector('link[rel="icon"]');
+            if (link) link.href = link.href.replace('%23F7931A', '%2300ffff');
+        }
+
         // ── Keyspace Tabs ──
         let pendingActivateId = null;
         let _lastPuzzles = [];   // cache for optimistic re-render on activation
@@ -839,6 +850,7 @@
                 const res = await fetch(url);
                 const data = await res.json();
 
+                applyStage(data.stage);
                 renderKeyspaceTabs(data.puzzles || []);
                 document.getElementById('total-hashrate').textContent = formatHashrate(data.total_hashrate);
                 document.getElementById('active-workers').textContent = data.active_workers_count;

--- a/server.js
+++ b/server.js
@@ -291,6 +291,7 @@ app.get('/api/v1/stats', (req, res) => {
     const allPuzzles = db.prepare("SELECT id, name, active FROM puzzles ORDER BY id ASC").all();
 
     res.json({
+        stage: process.env.STAGE || 'PROD',
         puzzles: allPuzzles,
         puzzle: puzzle ? {
             id: puzzle.id,


### PR DESCRIPTION
## Summary

- New `STAGE` env var (`PROD` / `TEST`) in `.env.example`
- `/api/v1/stats` response includes `stage` field
- Dashboard swaps the favicon circle from Bitcoin orange to cyan when `STAGE=TEST`, making browser tabs easy to distinguish between prod and test

## Test plan

- [ ] Add `STAGE=TEST` to the test server `.env`, restart
- [ ] Verify browser tab favicon is cyan on test.puzzle.b58.de
- [ ] Verify browser tab favicon remains orange on puzzle.b58.de (STAGE=PROD or unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)