### PR TITLE
fix: black bitcoin symbol on cyan test favicon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -433,9 +433,9 @@
             if (_stageSet) return;
             _stageSet = true;
             if (stage !== 'TEST') return;
-            // Swap favicon circle from Bitcoin orange (#F7931A) to cyan (#00ffff)
+            // Swap favicon: cyan circle + black symbol (instead of orange circle + white symbol)
             const link = document.querySelector('link[rel="icon"]');
-            if (link) link.href = link.href.replace('%23F7931A', '%2300ffff');
+            if (link) link.href = link.href.replace('%23F7931A', '%2300ffff').replace('%23FFF', '%23000');
         }
 
         // ── Keyspace Tabs ──


### PR DESCRIPTION
## Summary

- Test instance favicon: black Bitcoin symbol on cyan background (was white on cyan — hard to read)

## Test plan

- [ ] Merge, deploy to test, add `STAGE=TEST` to `.env`, restart
- [ ] Verify browser tab shows cyan circle with black Bitcoin symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)