### PR TITLE
Fix issues #11, #12, #13 + nginx/modal follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,31 +176,46 @@ See [docs/testing.md](docs/testing.md) for test scenarios and manual verificatio
 
 ---
 
-## Contributing
+## Branching strategy
 
-### Branch naming
+| Branch | Purpose |
+|--------|---------|
+| `main` | Production-ready code. Always matches what runs on prod. |
+| `dev` | Active development. Test server always tracks this branch. |
+| `feat/<topic>` | Optional isolation for large or risky changes — branch off `dev`, PR back into `dev`. |
 
-| Prefix | Use |
-|--------|-----|
-| `feat/` | New features |
-| `fix/` | Bug fixes |
-| `docs/` | Documentation only |
+```
+feat/xyz  ●──●──●
+                ↓ PR → dev
+dev       ●─────●──●──●──●
+                          ↓ PR → main (after tester approval)
+main      ●───────────────●  ← tag v1.x
+```
 
-### Workflow
+### Day-to-day workflow
 
-1. Fork the repo and create a branch from `main`
-2. Make your changes — add tests for new behaviour
-3. Run `npm test` and `npm run lint` — both must pass
-4. If you changed API routes, update `docs/api.md`
-5. Open a Pull Request — fill in the PR template checklist
-6. CI runs automatically; a maintainer will review within a few days
-7. Approved PRs are squash-merged into `main` and auto-deployed
+- **Small changes** — commit directly to `dev`; test server picks them up on next deploy
+- **Larger/risky changes** — open a `feat/` branch off `dev`, get it reviewed, merge to `dev`
+- **Ship to prod** — open a PR from `dev → main`; merge after tester confirms; tag the release
+
+### Tagging releases
+
+```bash
+git tag v1.x && git push origin v1.x
+```
+
+### Deployment
+
+| Environment | Tracks | Update command |
+|-------------|--------|----------------|
+| Test server | `dev` | `git pull origin dev` (in `update.sh`) |
+| Production  | `main` | `git pull origin main` (in `update.sh`) |
 
 ### Review process
 
 - `main` is protected — requires 1 approval and passing CI
 - The `/review-pr` Claude skill can generate a structured review draft
-- All review conversations must be resolved before merge
+- If you changed API routes, update `docs/api.md` in the same commit
 - Security issues: use GitHub's **private vulnerability reporting** (Security tab)
 
 ---

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -34,7 +34,18 @@ server {
     add_header X-Frame-Options         SAMEORIGIN;
     add_header Referrer-Policy         strict-origin-when-cross-origin;
 
-    # --- All admin routes: IP restriction ---
+    # --- activate-puzzle: browser-accessible, auth enforced server-side by ADMIN_TOKEN ---
+    location /api/v1/admin/activate-puzzle {
+        proxy_pass         http://127.0.0.1:8888;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        client_max_body_size 16k;
+    }
+
+    # --- All other admin routes: IP restriction ---
     # Only allow admin API calls from localhost and your trusted management IP.
     location /api/v1/admin/ {
         allow 127.0.0.1;

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -34,19 +34,7 @@ server {
     add_header X-Frame-Options         SAMEORIGIN;
     add_header Referrer-Policy         strict-origin-when-cross-origin;
 
-    # --- activate-puzzle: called from dashboard browser, allow public access ---
-    # Server-side ADMIN_TOKEN auth still applies if configured.
-    location /api/v1/admin/activate-puzzle {
-        proxy_pass         http://127.0.0.1:8888;
-        proxy_http_version 1.1;
-        proxy_set_header   Host              $host;
-        proxy_set_header   X-Real-IP         $remote_addr;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Proto $scheme;
-        client_max_body_size 16k;
-    }
-
-    # --- All other admin routes: IP restriction ---
+    # --- All admin routes: IP restriction ---
     # Only allow admin API calls from localhost and your trusted management IP.
     location /api/v1/admin/ {
         allow 127.0.0.1;

--- a/public/index.html
+++ b/public/index.html
@@ -62,6 +62,7 @@
             margin-bottom: 2.5rem;
             padding-bottom: 1.5rem;
             border-bottom: 1px solid var(--border-default);
+            position: relative;
         }
 
         .header h1 { font-family: var(--font-mono); font-size: 1.75rem; font-weight: 700; color: var(--accent-cyan); text-shadow: 0 0 20px var(--accent-cyan-glow); letter-spacing: 0.05em; }
@@ -208,7 +209,8 @@
     <div class="container">
         <!-- Header -->
         <div class="header">
-            <h1>PUZZLE POOL <span id="stage-label" style="display:none;font-size:0.75rem;color:var(--accent-red);font-weight:600;letter-spacing:0.08em;">/test system/</span></h1>
+            <h1>PUZZLE POOL</h1>
+            <span id="stage-label" style="display:none;position:absolute;left:50%;transform:translateX(-50%);font-family:var(--font-mono);font-size:1.45rem;font-weight:700;color:var(--accent-red);letter-spacing:0.05em;">/TEST SYSTEM/</span>
             <div class="status-badge"><div class="status-dot"></div>ONLINE</div>
         </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -580,8 +580,9 @@
                     pendingActivateId = null;
                     updateDashboard();
                 } else {
-                    const err = await res.json();
-                    errEl.textContent = err.error || `Error ${res.status}`;
+                    let msg = `Error ${res.status}`;
+                    try { const err = await res.json(); msg = err.error || msg; } catch (_) {}
+                    errEl.textContent = msg;
                     errEl.style.display = 'block';
                     if (res.status === 401) sessionStorage.removeItem('adminToken');
                 }

--- a/public/index.html
+++ b/public/index.html
@@ -593,8 +593,10 @@
 
         function formatETA(totalKeys, keysCompleted, hashrate) {
             if (hashrate <= 0) return '∞';
-            const remaining = BigInt(totalKeys) - BigInt(keysCompleted);
-            if (remaining <= 0n) return 'Complete';
+            const remaining = BigInt(totalKeys) - BigInt(keysCompleted) > 0n
+                ? BigInt(totalKeys) - BigInt(keysCompleted)
+                : 0n;
+            if (remaining === 0n) return 'Complete';
             // Use BigInt arithmetic to avoid float overflow on universe-scale keyspaces
             const remainingYears = remaining / BigInt(Math.round(hashrate * 365.25 * 86400));
             if (remainingYears > 999_999_999_999n) return '> 1 trillion years';

--- a/public/index.html
+++ b/public/index.html
@@ -210,7 +210,7 @@
         <!-- Header -->
         <div class="header">
             <h1>PUZZLE POOL</h1>
-            <span id="stage-label" style="display:none;position:absolute;left:50%;transform:translateX(-50%);font-family:var(--font-mono);font-size:1.45rem;font-weight:700;color:var(--accent-red);letter-spacing:0.05em;">/TEST SYSTEM/</span>
+            <span id="stage-label" style="display:none;position:absolute;left:50%;transform:translateX(-50%);font-family:var(--font-mono);font-size:0.8rem;font-weight:700;color:var(--accent-red);letter-spacing:0.05em;">/TEST SYSTEM/</span>
             <div class="status-badge"><div class="status-dot"></div>ONLINE</div>
         </div>
 

--- a/server.js
+++ b/server.js
@@ -223,9 +223,27 @@ app.get('/api/v1/stats', (req, res) => {
         WHERE puzzle_id = ? AND (status = 'completed' OR status = 'FOUND') AND worker_name IS NOT NULL
     `).all(pid) : [];
 
+    // Merge overlapping intervals before summing to avoid double-counting reclaimed/re-issued chunks
     let totalKeysCompleted = 0n;
-    for (const c of doneChunks) {
-        totalKeysCompleted += BigInt('0x' + c.end_hex) - BigInt('0x' + c.start_hex);
+    if (doneChunks.length > 0) {
+        const sorted = [...doneChunks].sort((a, b) => {
+            const diff = BigInt('0x' + a.start_hex) - BigInt('0x' + b.start_hex);
+            return diff < 0n ? -1 : diff > 0n ? 1 : 0;
+        });
+        let mergeStart = BigInt('0x' + sorted[0].start_hex);
+        let mergeEnd   = BigInt('0x' + sorted[0].end_hex);
+        for (let i = 1; i < sorted.length; i++) {
+            const s = BigInt('0x' + sorted[i].start_hex);
+            const e = BigInt('0x' + sorted[i].end_hex);
+            if (s <= mergeEnd) {
+                if (e > mergeEnd) mergeEnd = e;
+            } else {
+                totalKeysCompleted += mergeEnd - mergeStart;
+                mergeStart = s;
+                mergeEnd   = e;
+            }
+        }
+        totalKeysCompleted += mergeEnd - mergeStart;
     }
 
     const workerStats = {};

--- a/server.js
+++ b/server.js
@@ -131,11 +131,17 @@ app.post('/api/v1/work', (req, res) => {
             `).get(puzzle.id, puzzle.test_start_hex);
 
             if (testReclaimed) {
-                chunkId  = testReclaimed.id;
-                startHex = testReclaimed.start_hex;
-                endHex   = testReclaimed.end_hex;
-                db.prepare("UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP WHERE id = ?")
-                    .run(name, chunkId);
+                const assigned = db.prepare(`
+                    UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
+                    WHERE id = (
+                        SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND status = 'reclaimed' LIMIT 1
+                    )
+                    RETURNING *
+                `).get(name, puzzle.id, puzzle.test_start_hex);
+                if (!assigned) return res.status(503).json({ error: "No work available" });
+                chunkId  = assigned.id;
+                startHex = assigned.start_hex;
+                endHex   = assigned.end_hex;
             } else {
                 startHex = puzzle.test_start_hex;
                 endHex   = puzzle.test_end_hex;
@@ -151,17 +157,19 @@ app.post('/api/v1/work', (req, res) => {
         }
     }
 
-    // PRIORITY 2: Reissue reclaimed (timed-out) chunks
-    const reclaimed = db.prepare(
-        "SELECT * FROM chunks WHERE status = 'reclaimed' AND puzzle_id = ? LIMIT 1"
-    ).get(puzzle.id);
+    // PRIORITY 2: Reissue reclaimed (timed-out) chunks — atomic fetch-and-assign
+    const reclaimed = db.prepare(`
+        UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
+        WHERE id = (
+            SELECT id FROM chunks WHERE status = 'reclaimed' AND puzzle_id = ? LIMIT 1
+        )
+        RETURNING *
+    `).get(name, puzzle.id);
 
     if (reclaimed) {
         chunkId  = reclaimed.id;
         startHex = reclaimed.start_hex;
         endHex   = reclaimed.end_hex;
-        db.prepare("UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP WHERE id = ?")
-            .run(name, chunkId);
     } else {
         // PRIORITY 3: New random chunk
         ({ chunkId, startHex, endHex } = assignRandomChunk(name, hashrate, puzzle));

--- a/server.js
+++ b/server.js
@@ -66,25 +66,6 @@ function createApp(db) {
     app.use(express.static('public'));
 
     // Optional admin token guard — enabled only when ADMIN_TOKEN env var is set.
-    // activate-puzzle is registered before this middleware so tab clicks in the
-    // dashboard can switch puzzles without a token (nginx already restricts access).
-    app.post('/api/v1/admin/activate-puzzle', (req, res) => {
-        const { id } = req.body;
-        if (!id) return res.status(400).json({ error: 'Missing id' });
-
-        const target = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
-        if (!target) return res.status(404).json({ error: 'Puzzle not found' });
-
-        db.transaction(() => {
-            db.prepare("UPDATE puzzles SET active = 0").run();
-            db.prepare("UPDATE puzzles SET active = 1 WHERE id = ?").run(id);
-        })();
-
-        const puzzle = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
-        console.log(`[Admin] Active puzzle switched to: ${puzzle.name}`);
-        res.json({ ok: true, puzzle });
-    });
-
     if (process.env.ADMIN_TOKEN) {
         app.use('/api/v1/admin', (req, res, next) => {
             if (req.headers['x-admin-token'] === process.env.ADMIN_TOKEN) return next();
@@ -424,7 +405,25 @@ app.post('/api/v1/admin/set-test-chunk', (req, res) => {
     res.json({ ok: true, test_chunk: { start_hex: startNorm, end_hex: endNorm } });
 });
 
-// 6. Admin: list all puzzles
+// 6. Admin: switch active puzzle
+    app.post('/api/v1/admin/activate-puzzle', (req, res) => {
+        const { id } = req.body;
+        if (!id) return res.status(400).json({ error: 'Missing id' });
+
+        const target = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
+        if (!target) return res.status(404).json({ error: 'Puzzle not found' });
+
+        db.transaction(() => {
+            db.prepare("UPDATE puzzles SET active = 0").run();
+            db.prepare("UPDATE puzzles SET active = 1 WHERE id = ?").run(id);
+        })();
+
+        const puzzle = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
+        console.log(`[Admin] Active puzzle switched to: ${puzzle.name}`);
+        res.json({ ok: true, puzzle });
+    });
+
+// 7. Admin: list all puzzles
     app.get('/api/v1/admin/puzzles', (req, res) => {
         const puzzles = db.prepare("SELECT * FROM puzzles ORDER BY id ASC").all();
         res.json({ puzzles });


### PR DESCRIPTION
## Summary

- **#11** — Merge overlapping completed chunks before summing progress to prevent >100% completion and negative ETAs
- **#12** — Replace SELECT + UPDATE pairs in `/api/v1/work` with atomic `UPDATE … RETURNING` to eliminate the reclaimed-chunk race condition
- **#13** — Move `activate-puzzle` behind the `ADMIN_TOKEN` middleware; restore nginx proxy location so browser requests reach the server; harden modal error handler against non-JSON error responses

## Test plan

- [x] All 24 Jest tests pass (`npm test`)
- [x] POST `/api/v1/admin/activate-puzzle` without token → `401`
- [x] POST with correct `X-Admin-Token` → puzzle switches successfully
- [x] Dashboard progress never exceeds 100% even with overlapping completed chunks
- [x] No duplicate chunk assignments under concurrent `/work` requests
- [x] After nginx reload, activate-puzzle modal works end-to-end from the browser