### PR TITLE
fix: add chunks index, clarify hex normalization, document range semantics (#15)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -28,6 +28,12 @@ Request the next keyspace chunk to scan.
 { "job_id": 42, "start_key": "000...0600000000000000000", "end_key": "000...06000002bf20000000" }
 ```
 
+| Field | Type | Description |
+|-------|------|-------------|
+| `job_id` | number | Chunk identifier — required for `/submit` and `/heartbeat` |
+| `start_key` | string | First key to scan (inclusive) |
+| `end_key` | string | Scan boundary (exclusive) — scan the half-open range `[start_key, end_key)` |
+
 **Response 503** — no active puzzle configured
 ```json
 { "error": "No active puzzle configured" }

--- a/server.js
+++ b/server.js
@@ -11,7 +11,8 @@ const TIMEOUT_MINUTES = parseInt(process.env.TIMEOUT_MINUTES || '15',   10);
 
 // --- Pure helpers (no db dependency) ---
 
-// Validate that a string is a non-empty hex string (0x prefix optional)
+// Validate that a string is a non-empty hex string (0x prefix optional, any case).
+// Callers must normalize (strip 0x, lowercase, padStart) before any DB write or comparison.
 function isValidHex(s) {
     if (typeof s !== 'string' || s.length === 0) return false;
     return /^(0x)?[0-9a-fA-F]+$/.test(s);
@@ -461,6 +462,7 @@ if (require.main === module) {
         found_key TEXT,
         found_address TEXT
       );
+      CREATE INDEX IF NOT EXISTS idx_chunks_puzzle_status ON chunks (puzzle_id, status);
       CREATE TABLE IF NOT EXISTS findings (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         chunk_id INTEGER NOT NULL,


### PR DESCRIPTION
## Summary

- Add `CREATE INDEX IF NOT EXISTS idx_chunks_puzzle_status ON chunks(puzzle_id, status)` — prevents full table scans on stats/reclaim queries as chunk rows grow
- Document `end_key` as exclusive in `docs/api.md` — workers should scan `[start_key, end_key)`. Math was already correct; contract is now explicit.
- Add clarifying comment to `isValidHex` noting callers must normalize before DB writes

## Test plan

- [x] All 24 Jest tests pass (`npm test`)
- [x] After server restart, `EXPLAIN QUERY PLAN` on chunks queries shows `USING INDEX idx_chunks_puzzle_status`
- [x] Dashboard stats and reclaim task behave identically to before

Closes #15