### PR TITLE
feat: sharded sector frontiers — zero-overlap chunk allocation (#17)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -345,19 +345,24 @@
             <div class="api-body">
                 <div class="api-panel">
                     <div class="api-panel-label">Request</div>
-                    <pre class="request">{
-  "name":          "rig-01",   <span class="comment">// must match name used in /work</span>
-  "job_id":        42,         <span class="comment">// job_id returned by /work</span>
-  "status":        "done",     <span class="comment">// "done" or "FOUND" (case-sensitive; anything else is rejected)</span>
-  "found_key":     "0x...",    <span class="comment">// required when status == "FOUND"</span>
-  "found_address": "bc1..."    <span class="comment">// optional when status == "FOUND"</span>
+                    <pre class="request"><span class="comment">// Chunk completed normally:</span>
+{ "name": "rig-01", "job_id": 42, "status": "done" }
+
+<span class="comment">// Key found (status is case-sensitive; anything else returns 400):</span>
+{
+  "name":          "rig-01",
+  "job_id":        42,
+  "status":        "FOUND",
+  "found_key":     "0x...",  <span class="comment">// required</span>
+  "found_address": "bc1..."  <span class="comment">// optional</span>
 }</pre>
                 </div>
                 <div class="api-panel">
                     <div class="api-panel-label">Response</div>
                     <pre>{
-  "accepted": true  <span class="comment">// false if job_id unknown / already closed; 400 if status or found_key invalid</span>
-}</pre>
+  "accepted": true   <span class="comment">// false if job_id unknown or already closed</span>
+}
+<span class="comment">// 400 if status is invalid or found_key is missing for FOUND</span></pre>
                 </div>
             </div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -335,7 +335,8 @@
   "job_id":    42,         <span class="comment">// echo back in submit / heartbeat</span>
   "start_key": "0x...00", <span class="comment">// inclusive range start (hex)</span>
   "end_key":   "0x...1c"  <span class="comment">// exclusive range end   (hex) — scan [start_key, end_key)</span>
-}</pre>
+}
+<span class="comment">// If this worker already has an assigned chunk, the same job is returned again.</span></pre>
                 </div>
             </div>
         </div>
@@ -345,10 +346,11 @@
                 <div class="api-panel">
                     <div class="api-panel-label">Request</div>
                     <pre class="request">{
-  "name":    "rig-01", <span class="comment">// must match name used in /work</span>
-  "job_id":  42,       <span class="comment">// job_id returned by /work</span>
-  "status":  "done",   <span class="comment">// "done" | "FOUND"</span>
-  "found_address": ""  <span class="comment">// only when status == "FOUND"</span>
+  "name":          "rig-01",   <span class="comment">// must match name used in /work</span>
+  "job_id":        42,         <span class="comment">// job_id returned by /work</span>
+  "status":        "done",     <span class="comment">// "done" or "FOUND" (case-sensitive; anything else is rejected)</span>
+  "found_key":     "0x...",    <span class="comment">// required when status == "FOUND"</span>
+  "found_address": "bc1..."    <span class="comment">// optional when status == "FOUND"</span>
 }</pre>
                 </div>
                 <div class="api-panel">

--- a/public/index.html
+++ b/public/index.html
@@ -356,7 +356,7 @@
                 <div class="api-panel">
                     <div class="api-panel-label">Response</div>
                     <pre>{
-  "accepted": true  <span class="comment">// false if job_id unknown / already closed</span>
+  "accepted": true  <span class="comment">// false if job_id unknown / already closed; 400 if status or found_key invalid</span>
 }</pre>
                 </div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -334,7 +334,7 @@
                     <pre>{
   "job_id":    42,         <span class="comment">// echo back in submit / heartbeat</span>
   "start_key": "0x...00", <span class="comment">// inclusive range start (hex)</span>
-  "end_key":   "0x...1c"  <span class="comment">// inclusive range end   (hex)</span>
+  "end_key":   "0x...1c"  <span class="comment">// exclusive range end   (hex) — scan [start_key, end_key)</span>
 }</pre>
                 </div>
             </div>
@@ -347,8 +347,8 @@
                     <pre class="request">{
   "name":    "rig-01", <span class="comment">// must match name used in /work</span>
   "job_id":  42,       <span class="comment">// job_id returned by /work</span>
-  "status":  "done",   <span class="comment">// "done" | "found"</span>
-  "found_address": ""  <span class="comment">// only when status == "found"</span>
+  "status":  "done",   <span class="comment">// "done" | "FOUND"</span>
+  "found_address": ""  <span class="comment">// only when status == "FOUND"</span>
 }</pre>
                 </div>
                 <div class="api-panel">
@@ -907,7 +907,7 @@
                 else stbody.innerHTML = data.scores.map((s, i) => `<tr>
                     <td class="td-rank">#${i+1}</td>
                     <td class="td-name">${s.worker_name}</td>
-                    <td class="td-chunks">${Number(s.total_keys).toLocaleString()}</td>
+                    <td class="td-chunks">${formatBigInt(s.total_keys)}</td>
                     <td class="td-chunks">${s.completed_chunks.toLocaleString()}</td>
                 </tr>`).join('');
 

--- a/server.js
+++ b/server.js
@@ -170,11 +170,12 @@ app.post('/api/v1/work', (req, res) => {
     const { name, hashrate } = req.body;
     if (!name) return res.status(400).json({ error: "Missing name" });
 
-    // Upsert worker
+    // Upsert worker — store normalized hashrate so /stats sorting and totals are safe
+    const hashrateNum = Number(normalizeHashrate(hashrate));
     db.prepare(`
         INSERT INTO workers (name, hashrate, last_seen) VALUES (?, ?, CURRENT_TIMESTAMP)
         ON CONFLICT(name) DO UPDATE SET hashrate = excluded.hashrate, last_seen = CURRENT_TIMESTAMP
-    `).run(name, hashrate || 0);
+    `).run(name, hashrateNum);
 
     // Fetch active puzzle
     const puzzle = db.prepare("SELECT * FROM puzzles WHERE active = 1 LIMIT 1").get();
@@ -479,8 +480,11 @@ app.post('/api/v1/admin/set-test-chunk', (req, res) => {
     if (te <= ts) {
         return res.status(400).json({ error: "end_hex must be greater than start_hex" });
     }
-    if (ts < ps || te > pe) {
-        return res.status(400).json({ error: "Test chunk must lie within active puzzle range" });
+    // Test chunks must lie OUTSIDE the active puzzle range so the sector allocator
+    // can never hand out the same keys as a fresh production chunk.
+    const overlaps = ts < pe && ps < te;
+    if (overlaps) {
+        return res.status(400).json({ error: "Test chunk must not overlap the active puzzle range" });
     }
 
     db.prepare("UPDATE puzzles SET test_start_hex = ?, test_end_hex = ? WHERE id = ?")

--- a/server.js
+++ b/server.js
@@ -183,10 +183,10 @@ app.post('/api/v1/work', (req, res) => {
     const puzzle = db.prepare("SELECT * FROM puzzles WHERE active = 1 LIMIT 1").get();
     if (!puzzle) return res.status(503).json({ error: "No active puzzle configured" });
 
-    // Idempotency: if the worker already holds an assigned production chunk, return it.
-    // Enforces at-most-one-chunk-per-worker and prevents pool starvation from greedy clients.
+    // Idempotency: if the worker already holds any assigned chunk (test or production),
+    // return it. Enforces one chunk total per worker and prevents pool starvation.
     const existing = db.prepare(
-        "SELECT id, start_hex, end_hex FROM chunks WHERE worker_name = ? AND puzzle_id = ? AND status = 'assigned' AND is_test = 0 LIMIT 1"
+        "SELECT id, start_hex, end_hex FROM chunks WHERE worker_name = ? AND puzzle_id = ? AND status = 'assigned' LIMIT 1"
     ).get(name, puzzle.id);
     if (existing) return res.json({ job_id: existing.id, start_key: existing.start_hex, end_key: existing.end_hex });
 
@@ -232,9 +232,10 @@ app.post('/api/v1/submit', (req, res) => {
     const { name, job_id, status, found_key, found_address } = req.body;
 
     if (status === "FOUND") {
-        // Update chunk first; only write side-effects (log, findings) if ownership confirmed.
+        // Update chunk first (status guard prevents invalid transitions from non-assigned rows).
+        // Only write BINGO log and findings if the chunk was actually ours to update.
         const info = db.prepare(
-            "UPDATE chunks SET status = 'FOUND', found_key = COALESCE(found_key, ?), found_address = COALESCE(found_address, ?) WHERE id = ? AND worker_name = ?"
+            "UPDATE chunks SET status = 'FOUND', found_key = COALESCE(found_key, ?), found_address = COALESCE(found_address, ?) WHERE id = ? AND worker_name = ? AND status = 'assigned'"
         ).run(found_key, found_address || null, job_id, name);
 
         if (!info.changes) return res.json({ accepted: false });
@@ -248,17 +249,18 @@ app.post('/api/v1/submit', (req, res) => {
         db.prepare("INSERT INTO findings (chunk_id, worker_name, found_key, found_address) VALUES (?, ?, ?, ?)")
             .run(job_id, name, found_key, found_address || null);
     } else {
-        const info = db.prepare("UPDATE chunks SET status = 'completed' WHERE id = ? AND worker_name = ?")
+        const info = db.prepare("UPDATE chunks SET status = 'completed' WHERE id = ? AND worker_name = ? AND status = 'assigned'")
             .run(job_id, name);
         if (!info.changes) return res.json({ accepted: false });
     }
 
     // Auto-clear test chunk config after a successful submission so the test is one-shot.
-    // The admin must call set-test-chunk again to issue another test.
-    const chunk = db.prepare("SELECT is_test, puzzle_id FROM chunks WHERE id = ?").get(job_id);
+    // Match on start_hex/end_hex so a newer test set by the admin before this submit
+    // arrives is not accidentally erased.
+    const chunk = db.prepare("SELECT is_test, puzzle_id, start_hex, end_hex FROM chunks WHERE id = ?").get(job_id);
     if (chunk?.is_test) {
-        db.prepare("UPDATE puzzles SET test_start_hex = NULL, test_end_hex = NULL WHERE id = ?")
-            .run(chunk.puzzle_id);
+        db.prepare("UPDATE puzzles SET test_start_hex = NULL, test_end_hex = NULL WHERE id = ? AND test_start_hex = ? AND test_end_hex = ?")
+            .run(chunk.puzzle_id, chunk.start_hex, chunk.end_hex);
         console.log(`[Test] Test chunk #${job_id} completed — test config cleared from puzzle ${chunk.puzzle_id}`);
     }
 

--- a/server.js
+++ b/server.js
@@ -241,8 +241,11 @@ app.post('/api/v1/submit', (req, res) => {
         if (!info.changes) {
             // Late FOUND: chunk was reclaimed/reassigned before submission. Accept if this
             // worker was the previous legitimate assignee so the key is never lost.
+            // Only accept late FOUND while the chunk is still in-progress (assigned to
+            // someone else or reclaimed). Reject if already finalized (FOUND/completed)
+            // to prevent duplicate accepted winners on the same chunk.
             const wasPrev = db.prepare(
-                "SELECT id FROM chunks WHERE id = ? AND prev_worker_name = ?"
+                "SELECT id FROM chunks WHERE id = ? AND prev_worker_name = ? AND status IN ('assigned', 'reclaimed')"
             ).get(job_id, name);
             if (!wasPrev) return res.json({ accepted: false });
             // Chunk now belongs to another worker — log the key but leave chunk status alone.

--- a/server.js
+++ b/server.js
@@ -80,10 +80,12 @@ function createApp(db) {
     const stmtSectorDone      = db.prepare("UPDATE sectors SET current_hex = end_hex, status = 'done' WHERE id = ?");
     const stmtSectorAdvance   = db.prepare("UPDATE sectors SET current_hex = ? WHERE id = ?");
     const stmtInsertChunk     = db.prepare("INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at, is_test) VALUES (?, ?, ?, 'assigned', ?, CURRENT_TIMESTAMP, 0)");
-    const stmtTestChunkTaken  = db.prepare("SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND status IN ('assigned', 'completed', 'FOUND') LIMIT 1");
+    // Both taken/reclaim queries match on start_hex + end_hex + is_test = 1 so a different
+    // test chunk with the same start but different end cannot interfere.
+    const stmtTestChunkTaken  = db.prepare("SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND end_hex = ? AND is_test = 1 AND status IN ('assigned', 'completed', 'FOUND') LIMIT 1");
     const stmtTestChunkReclaim = db.prepare(`
         UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
-        WHERE id = (SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND status = 'reclaimed' LIMIT 1)
+        WHERE id = (SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND end_hex = ? AND is_test = 1 AND status = 'reclaimed' LIMIT 1)
         RETURNING *
     `);
     const stmtTestChunkInsert = db.prepare(`
@@ -132,10 +134,14 @@ function createApp(db) {
     // Test chunk claiming — IMMEDIATE transaction to prevent two concurrent requests
     // from both passing the "not yet taken" check before either inserts.
     // is_test = 1 is set on insert so these rows are excluded from puzzle stats.
+    // Completed/FOUND test chunks count as permanently taken; admins who want to rerun
+    // a test should call set-test-chunk again (even with the same range) — the next
+    // /work request will issue a fresh insert because the old row has a different end_hex
+    // or the taken check won't match a re-set range.
     const claimTestChunk = db.transaction((name, puzzle) => {
-        const taken = stmtTestChunkTaken.get(puzzle.id, puzzle.test_start_hex);
+        const taken = stmtTestChunkTaken.get(puzzle.id, puzzle.test_start_hex, puzzle.test_end_hex);
         if (taken) return null;
-        const reclaimed = stmtTestChunkReclaim.get(name, puzzle.id, puzzle.test_start_hex);
+        const reclaimed = stmtTestChunkReclaim.get(name, puzzle.id, puzzle.test_start_hex, puzzle.test_end_hex);
         if (reclaimed) return reclaimed;
         return stmtTestChunkInsert.get(puzzle.id, puzzle.test_start_hex, puzzle.test_end_hex, name);
     });
@@ -189,10 +195,11 @@ app.post('/api/v1/work', (req, res) => {
 
     // PRIORITY 2: Reissue reclaimed (timed-out) chunks — atomic fetch-and-assign.
     // Sector frontiers are never rolled back on reclaim; chunks table is the reissue source.
+    // is_test = 0 guard prevents a reclaimed test chunk from leaking into normal work.
     const reclaimed = db.prepare(`
         UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
         WHERE id = (
-            SELECT id FROM chunks WHERE status = 'reclaimed' AND puzzle_id = ? LIMIT 1
+            SELECT id FROM chunks WHERE status = 'reclaimed' AND puzzle_id = ? AND is_test = 0 LIMIT 1
         )
         RETURNING *
     `).get(name, puzzle.id);
@@ -249,7 +256,7 @@ app.get('/api/v1/stats', (req, res) => {
     const activeWorkers = pid ? db.prepare(`
         SELECT DISTINCT w.name, w.hashrate, w.last_seen
         FROM workers w
-        JOIN chunks c ON c.worker_name = w.name AND c.status = 'assigned' AND c.puzzle_id = ?
+        JOIN chunks c ON c.worker_name = w.name AND c.status = 'assigned' AND c.puzzle_id = ? AND c.is_test = 0
         WHERE w.last_seen >= datetime('now', '-10 minutes')
         ORDER BY w.hashrate DESC
     `).all(pid) : [];
@@ -312,12 +319,12 @@ app.get('/api/v1/stats', (req, res) => {
         SELECT f.worker_name, f.found_key, f.found_address, f.created_at
         FROM findings f
         JOIN chunks c ON c.id = f.chunk_id
-        WHERE c.puzzle_id = ?
+        WHERE c.puzzle_id = ? AND c.is_test = 0
         ORDER BY f.id ASC
     `).all(pid) : [];
 
     const assignedNow = puzzle
-        ? db.prepare("SELECT id, worker_name FROM chunks WHERE status = 'assigned' AND puzzle_id = ?").all(puzzle.id)
+        ? db.prepare("SELECT id, worker_name FROM chunks WHERE status = 'assigned' AND puzzle_id = ? AND is_test = 0").all(puzzle.id)
         : [];
     const workerChunkMap = {};
     for (const c of assignedNow) workerChunkMap[c.worker_name] = c.id;
@@ -574,7 +581,24 @@ if (require.main === module) {
 
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_start_hex TEXT").run(); } catch (_) {}
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_end_hex   TEXT").run(); } catch (_) {}
-    try { db.prepare("ALTER TABLE chunks  ADD COLUMN is_test INTEGER NOT NULL DEFAULT 0").run(); } catch (_) {}
+    // is_test defaults to 0 for all pre-existing rows. Best-effort backfill: mark any chunk
+    // whose range exactly matches the puzzle's current test_start_hex/test_end_hex as is_test=1.
+    // Chunks from previously-used test ranges that no longer match cannot be recovered
+    // automatically — manual cleanup is required for those rows if they cause stats noise.
+    try {
+        db.prepare("ALTER TABLE chunks ADD COLUMN is_test INTEGER NOT NULL DEFAULT 0").run();
+        db.prepare(`
+            UPDATE chunks SET is_test = 1
+            WHERE is_test = 0
+              AND EXISTS (
+                SELECT 1 FROM puzzles p
+                WHERE p.id = chunks.puzzle_id
+                  AND p.test_start_hex IS NOT NULL
+                  AND chunks.start_hex = p.test_start_hex
+                  AND chunks.end_hex   = p.test_end_hex
+              )
+        `).run();
+    } catch (_) {}
 
     // Seed puzzles from KEYSPACE_<NAME>=<start_hex>:<end_hex> env vars
     for (const [key, value] of Object.entries(process.env)) {

--- a/server.js
+++ b/server.js
@@ -75,11 +75,22 @@ function seedSectors(db, puzzleId, startHex, endHex) {
 
 function createApp(db) {
     // Prepared statements hoisted here so they are compiled once, not on every request.
-    const stmtOpenSector    = db.prepare("SELECT * FROM sectors WHERE puzzle_id = ? AND status = 'open' ORDER BY RANDOM() LIMIT 1");
-    const stmtWorkerHash    = db.prepare("SELECT hashrate FROM workers WHERE name = ?");
-    const stmtSectorDone    = db.prepare("UPDATE sectors SET current_hex = end_hex, status = 'done' WHERE id = ?");
-    const stmtSectorAdvance = db.prepare("UPDATE sectors SET current_hex = ? WHERE id = ?");
-    const stmtInsertChunk   = db.prepare("INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at) VALUES (?, ?, ?, 'assigned', ?, CURRENT_TIMESTAMP)");
+    const stmtOpenSector      = db.prepare("SELECT * FROM sectors WHERE puzzle_id = ? AND status = 'open' ORDER BY RANDOM() LIMIT 1");
+    const stmtWorkerHash      = db.prepare("SELECT hashrate FROM workers WHERE name = ?");
+    const stmtSectorDone      = db.prepare("UPDATE sectors SET current_hex = end_hex, status = 'done' WHERE id = ?");
+    const stmtSectorAdvance   = db.prepare("UPDATE sectors SET current_hex = ? WHERE id = ?");
+    const stmtInsertChunk     = db.prepare("INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at, is_test) VALUES (?, ?, ?, 'assigned', ?, CURRENT_TIMESTAMP, 0)");
+    const stmtTestChunkTaken  = db.prepare("SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND status IN ('assigned', 'completed', 'FOUND') LIMIT 1");
+    const stmtTestChunkReclaim = db.prepare(`
+        UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
+        WHERE id = (SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND status = 'reclaimed' LIMIT 1)
+        RETURNING *
+    `);
+    const stmtTestChunkInsert = db.prepare(`
+        INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at, is_test)
+        VALUES (?, ?, ?, 'assigned', ?, CURRENT_TIMESTAMP, 1)
+        RETURNING *
+    `);
 
     // Fresh allocation from sector frontier.
     // BEGIN IMMEDIATE acquires the write lock before the SELECT so two concurrent
@@ -120,29 +131,13 @@ function createApp(db) {
 
     // Test chunk claiming — IMMEDIATE transaction to prevent two concurrent requests
     // from both passing the "not yet taken" check before either inserts.
+    // is_test = 1 is set on insert so these rows are excluded from puzzle stats.
     const claimTestChunk = db.transaction((name, puzzle) => {
-        const taken = db.prepare(`
-            SELECT id FROM chunks
-            WHERE puzzle_id = ? AND start_hex = ?
-              AND status IN ('assigned', 'completed', 'FOUND')
-            LIMIT 1
-        `).get(puzzle.id, puzzle.test_start_hex);
+        const taken = stmtTestChunkTaken.get(puzzle.id, puzzle.test_start_hex);
         if (taken) return null;
-
-        const reclaimed = db.prepare(`
-            UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
-            WHERE id = (
-                SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND status = 'reclaimed' LIMIT 1
-            )
-            RETURNING *
-        `).get(name, puzzle.id, puzzle.test_start_hex);
+        const reclaimed = stmtTestChunkReclaim.get(name, puzzle.id, puzzle.test_start_hex);
         if (reclaimed) return reclaimed;
-
-        return db.prepare(`
-            INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at)
-            VALUES (?, ?, ?, 'assigned', ?, CURRENT_TIMESTAMP)
-            RETURNING *
-        `).get(puzzle.id, puzzle.test_start_hex, puzzle.test_end_hex, name);
+        return stmtTestChunkInsert.get(puzzle.id, puzzle.test_start_hex, puzzle.test_end_hex, name);
     });
 
     const app = express();
@@ -261,13 +256,13 @@ app.get('/api/v1/stats', (req, res) => {
     const totalHashrate = activeWorkers.reduce((sum, w) => sum + w.hashrate, 0);
 
     const completedChunks = pid ? db.prepare(
-        "SELECT COUNT(*) as count FROM chunks WHERE puzzle_id = ? AND (status = 'completed' OR status = 'FOUND')"
+        "SELECT COUNT(*) as count FROM chunks WHERE puzzle_id = ? AND (status = 'completed' OR status = 'FOUND') AND is_test = 0"
     ).get(pid).count : 0;
 
     const doneChunks = pid ? db.prepare(`
         SELECT worker_name, start_hex, end_hex
         FROM chunks
-        WHERE puzzle_id = ? AND (status = 'completed' OR status = 'FOUND') AND worker_name IS NOT NULL
+        WHERE puzzle_id = ? AND (status = 'completed' OR status = 'FOUND') AND worker_name IS NOT NULL AND is_test = 0
     `).all(pid) : [];
 
     // Merge overlapping intervals before summing. After the sector-frontier migration,
@@ -339,7 +334,7 @@ app.get('/api/v1/stats', (req, res) => {
         const pRange = pEnd - pStart;
         const rawChunks = db.prepare(`
             SELECT id, status, worker_name, start_hex, end_hex
-            FROM chunks WHERE puzzle_id = ?
+            FROM chunks WHERE puzzle_id = ? AND is_test = 0
             ORDER BY id ASC
         `).all(puzzle.id);
         chunks_vis = rawChunks.map(c => {
@@ -552,7 +547,8 @@ if (require.main === module) {
         worker_name TEXT,
         assigned_at DATETIME,
         found_key TEXT,
-        found_address TEXT
+        found_address TEXT,
+        is_test INTEGER NOT NULL DEFAULT 0
       );
       CREATE INDEX IF NOT EXISTS idx_chunks_puzzle_status ON chunks (puzzle_id, status);
       CREATE TABLE IF NOT EXISTS sectors (
@@ -578,6 +574,7 @@ if (require.main === module) {
 
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_start_hex TEXT").run(); } catch (_) {}
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_end_hex   TEXT").run(); } catch (_) {}
+    try { db.prepare("ALTER TABLE chunks  ADD COLUMN is_test INTEGER NOT NULL DEFAULT 0").run(); } catch (_) {}
 
     // Seed puzzles from KEYSPACE_<NAME>=<start_hex>:<end_hex> env vars
     for (const [key, value] of Object.entries(process.env)) {

--- a/server.js
+++ b/server.js
@@ -183,6 +183,13 @@ app.post('/api/v1/work', (req, res) => {
     const puzzle = db.prepare("SELECT * FROM puzzles WHERE active = 1 LIMIT 1").get();
     if (!puzzle) return res.status(503).json({ error: "No active puzzle configured" });
 
+    // Idempotency: if the worker already holds an assigned production chunk, return it.
+    // Enforces at-most-one-chunk-per-worker and prevents pool starvation from greedy clients.
+    const existing = db.prepare(
+        "SELECT id, start_hex, end_hex FROM chunks WHERE worker_name = ? AND puzzle_id = ? AND status = 'assigned' AND is_test = 0 LIMIT 1"
+    ).get(name, puzzle.id);
+    if (existing) return res.json({ job_id: existing.id, start_key: existing.start_hex, end_key: existing.end_hex });
+
     let chunkId, startHex, endHex;
 
     // PRIORITY 1: Test chunk — atomic IMMEDIATE claim; only one worker ever receives it.
@@ -225,6 +232,13 @@ app.post('/api/v1/submit', (req, res) => {
     const { name, job_id, status, found_key, found_address } = req.body;
 
     if (status === "FOUND") {
+        // Update chunk first; only write side-effects (log, findings) if ownership confirmed.
+        const info = db.prepare(
+            "UPDATE chunks SET status = 'FOUND', found_key = COALESCE(found_key, ?), found_address = COALESCE(found_address, ?) WHERE id = ? AND worker_name = ?"
+        ).run(found_key, found_address || null, job_id, name);
+
+        if (!info.changes) return res.json({ accepted: false });
+
         const msg = `[${new Date().toISOString()}] BINGO! Job: ${job_id} | Worker: ${name} | KEY: ${found_key} | ADDR: ${found_address || 'Unknown'}\n`;
         console.log(`\n🚨🚨🚨 ${msg}`);
         fs.appendFileSync('BINGO_FOUND_KEYS.txt', msg);
@@ -233,12 +247,19 @@ app.post('/api/v1/submit', (req, res) => {
         // joining to chunks.is_test. /stats already filters with AND c.is_test = 0.
         db.prepare("INSERT INTO findings (chunk_id, worker_name, found_key, found_address) VALUES (?, ?, ?, ?)")
             .run(job_id, name, found_key, found_address || null);
-
-        db.prepare("UPDATE chunks SET status = 'FOUND', found_key = COALESCE(found_key, ?), found_address = COALESCE(found_address, ?) WHERE id = ? AND worker_name = ?")
-            .run(found_key, found_address || null, job_id, name);
     } else {
-        db.prepare("UPDATE chunks SET status = 'completed' WHERE id = ? AND worker_name = ?")
+        const info = db.prepare("UPDATE chunks SET status = 'completed' WHERE id = ? AND worker_name = ?")
             .run(job_id, name);
+        if (!info.changes) return res.json({ accepted: false });
+    }
+
+    // Auto-clear test chunk config after a successful submission so the test is one-shot.
+    // The admin must call set-test-chunk again to issue another test.
+    const chunk = db.prepare("SELECT is_test, puzzle_id FROM chunks WHERE id = ?").get(job_id);
+    if (chunk?.is_test) {
+        db.prepare("UPDATE puzzles SET test_start_hex = NULL, test_end_hex = NULL WHERE id = ?")
+            .run(chunk.puzzle_id);
+        console.log(`[Test] Test chunk #${job_id} completed — test config cleared from puzzle ${chunk.puzzle_id}`);
     }
 
     res.json({ accepted: true });

--- a/server.js
+++ b/server.js
@@ -254,13 +254,13 @@ app.post('/api/v1/submit', (req, res) => {
             ).get(job_id, name);
             if (!latePrev) return res.json({ accepted: false });
 
-            if (latePrev.status === 'reclaimed') {
-                // Chunk belongs to nobody — claim it as FOUND so it leaves circulation.
-                db.prepare(
-                    "UPDATE chunks SET status = 'FOUND', worker_name = ?, found_key = COALESCE(found_key, ?), found_address = COALESCE(found_address, ?) WHERE id = ?"
-                ).run(name, found_key, found_address || null, job_id);
-            }
-            // If status is 'assigned' the chunk belongs to another worker — leave it alone.
+            // Finalize the chunk in all cases — whether currently assigned to someone else
+            // or reclaimed. An accepted late FOUND must not remain mutable; leaving it
+            // assigned would let the current holder later overwrite it with completed or
+            // create a second accepted winner.
+            db.prepare(
+                "UPDATE chunks SET status = 'FOUND', worker_name = ?, found_key = COALESCE(found_key, ?), found_address = COALESCE(found_address, ?) WHERE id = ?"
+            ).run(name, found_key, found_address || null, job_id);
             console.log(`[Late FOUND] Job: ${job_id} | Worker: ${name} (prev assignee) | KEY: ${found_key}`);
         }
 

--- a/server.js
+++ b/server.js
@@ -29,24 +29,78 @@ function randomBigIntInRange(min, max) {
     return min + (n % range);
 }
 
+// Divide puzzle keyspace into sectors with independent frontiers.
+// All intervals are half-open [start, end). numSectors clamped to [1, TARGET_SECTORS].
+function seedSectors(db, puzzleId, startHex, endHex) {
+    const TARGET_SECTORS  = 65536n;
+    const MIN_SECTOR_SIZE = 1_000_000_000n;
+
+    const start = BigInt('0x' + startHex);
+    const end   = BigInt('0x' + endHex);
+    const range = end - start;
+    if (range <= 0n) throw new Error('Puzzle range must be > 0');
+
+    let numSectors = range / MIN_SECTOR_SIZE;
+    if (numSectors < 1n)             numSectors = 1n;
+    if (numSectors > TARGET_SECTORS) numSectors = TARGET_SECTORS;
+
+    const sectorSize = range / numSectors;
+    const stmt = db.prepare(
+        "INSERT INTO sectors (puzzle_id, start_hex, end_hex, current_hex, status) VALUES (?, ?, ?, ?, 'open')"
+    );
+
+    db.transaction(() => {
+        for (let i = 0n; i < numSectors; i++) {
+            const s = start + i * sectorSize;
+            const e = (i === numSectors - 1n) ? end : s + sectorSize;
+            const sHex = s.toString(16).padStart(64, '0');
+            const eHex = e.toString(16).padStart(64, '0');
+            stmt.run(puzzleId, sHex, eHex, sHex);
+        }
+    })();
+
+    console.log(`[System] Seeded ${numSectors} sectors for puzzle ${puzzleId}`);
+}
+
 // --- App factory (accepts db for testability) ---
 
 function createApp(db) {
-    // Assign a chunk at a random position within the active puzzle range.
+    // Assign the next chunk from the sector frontier.
+    // Uses BEGIN IMMEDIATE so the write lock is acquired before the SELECT read,
+    // preventing two concurrent connections from observing the same open sector.
+    // Returns null when all sectors are exhausted (caller should respond 503).
+    // ORDER BY RANDOM() is a deliberate tradeoff — acceptable at ≤65,536 rows.
     const assignRandomChunk = db.transaction((name, hashrate, puzzle) => {
-        const stored = db.prepare("SELECT hashrate FROM workers WHERE name = ?").get(name);
-        const hashrateBig = BigInt(Math.floor(hashrate || stored?.hashrate || 1000000));
-        const chunkSize = hashrateBig * BigInt(TARGET_MINUTES * 60);
+        const sector = db.prepare(
+            "SELECT * FROM sectors WHERE puzzle_id = ? AND status = 'open' ORDER BY RANDOM() LIMIT 1"
+        ).get(puzzle.id);
+        if (!sector) return null;
 
-        const puzzleStart = BigInt('0x' + puzzle.start_hex);
-        const puzzleEnd   = BigInt('0x' + puzzle.end_hex);
+        const stored      = db.prepare("SELECT hashrate FROM workers WHERE name = ?").get(name);
+        const hashrateBig = BigInt(Math.floor(hashrate || stored?.hashrate || 1_000_000));
+        const chunkSize   = hashrateBig * BigInt(TARGET_MINUTES * 60);
 
-        const effectiveChunk = chunkSize < (puzzleEnd - puzzleStart) ? chunkSize : (puzzleEnd - puzzleStart);
-        const start = randomBigIntInRange(puzzleStart, puzzleEnd - effectiveChunk + 1n);
-        const end   = start + effectiveChunk;
+        const current   = BigInt('0x' + sector.current_hex);
+        const sectorEnd = BigInt('0x' + sector.end_hex);
+        const effective = chunkSize < (sectorEnd - current) ? chunkSize : (sectorEnd - current);
 
-        const startHex = start.toString(16).padStart(64, '0');
-        const endHex   = end.toString(16).padStart(64, '0');
+        // Defensive guard: sector should not be open with no space remaining
+        if (effective <= 0n) {
+            db.prepare("UPDATE sectors SET current_hex = end_hex, status = 'done' WHERE id = ?")
+                .run(sector.id);
+            return null;
+        }
+
+        const startHex = current.toString(16).padStart(64, '0');
+        const endHex   = (current + effective).toString(16).padStart(64, '0');
+
+        if (current + effective >= sectorEnd) {
+            db.prepare("UPDATE sectors SET current_hex = end_hex, status = 'done' WHERE id = ?")
+                .run(sector.id);
+        } else {
+            db.prepare("UPDATE sectors SET current_hex = ? WHERE id = ?")
+                .run(endHex, sector.id);
+        }
 
         const info = db.prepare(`
             INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at)
@@ -139,7 +193,8 @@ app.post('/api/v1/work', (req, res) => {
         }
     }
 
-    // PRIORITY 2: Reissue reclaimed (timed-out) chunks — atomic fetch-and-assign
+    // PRIORITY 2: Reissue reclaimed (timed-out) chunks — atomic fetch-and-assign.
+    // Sector frontiers are never rolled back on reclaim; chunks table is the reissue source.
     const reclaimed = db.prepare(`
         UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
         WHERE id = (
@@ -153,8 +208,11 @@ app.post('/api/v1/work', (req, res) => {
         startHex = reclaimed.start_hex;
         endHex   = reclaimed.end_hex;
     } else {
-        // PRIORITY 3: New random chunk
-        ({ chunkId, startHex, endHex } = assignRandomChunk(name, hashrate, puzzle));
+        // PRIORITY 3: Fresh allocation from sector frontier (BEGIN IMMEDIATE — write lock acquired
+        // before the sector SELECT so two concurrent connections cannot pick the same sector)
+        const result = assignRandomChunk.immediate(name, hashrate, puzzle);
+        if (!result) return res.status(503).json({ error: 'All keyspace has been assigned' });
+        ({ chunkId, startHex, endHex } = result);
     }
 
     res.json({ job_id: chunkId, start_key: startHex, end_key: endHex });
@@ -213,7 +271,9 @@ app.get('/api/v1/stats', (req, res) => {
         WHERE puzzle_id = ? AND (status = 'completed' OR status = 'FOUND') AND worker_name IS NOT NULL
     `).all(pid) : [];
 
-    // Merge overlapping intervals before summing to avoid double-counting reclaimed/re-issued chunks
+    // Merge overlapping intervals before summing. After the sector-frontier migration,
+    // fresh allocations never overlap; merging is retained to correctly handle duplicate
+    // history rows that can arise from reclaimed chunk reissue.
     let totalKeysCompleted = 0n;
     if (doneChunks.length > 0) {
         const sorted = [...doneChunks].sort((a, b) => {
@@ -343,7 +403,9 @@ app.post('/api/v1/heartbeat', (req, res) => {
     res.json({ ok: true });
 });
 
-// 5. Admin: switch active puzzle (or create + activate a new one)
+// 5. Admin: switch active puzzle (or create + activate a new one).
+// When the range changes for an existing named puzzle, a new puzzle row is inserted
+// so that old chunk history stays attached to the old puzzle_id and /stats remains correct.
 app.post('/api/v1/admin/set-puzzle', (req, res) => {
     const { name, start_hex, end_hex } = req.body;
     if (!name || !start_hex || !end_hex) {
@@ -356,15 +418,28 @@ app.post('/api/v1/admin/set-puzzle', (req, res) => {
     const startNorm = start_hex.replace(/^0x/i, '').padStart(64, '0').toLowerCase();
     const endNorm   = end_hex.replace(/^0x/i, '').padStart(64, '0').toLowerCase();
 
+    if (BigInt('0x' + endNorm) <= BigInt('0x' + startNorm)) {
+        return res.status(400).json({ error: "end_hex must be greater than start_hex" });
+    }
+
     db.transaction(() => {
         db.prepare("UPDATE puzzles SET active = 0").run();
-        const existing = db.prepare("SELECT id FROM puzzles WHERE name = ?").get(name);
-        if (existing) {
-            db.prepare("UPDATE puzzles SET start_hex = ?, end_hex = ?, active = 1 WHERE id = ?")
-                .run(startNorm, endNorm, existing.id);
+        const existing = db.prepare("SELECT * FROM puzzles WHERE name = ?").get(name);
+
+        let puzzleId;
+        if (existing && existing.start_hex === startNorm && existing.end_hex === endNorm) {
+            // Same range — reactivate; seed sectors only if missing (idempotent on restart)
+            db.prepare("UPDATE puzzles SET active = 1 WHERE id = ?").run(existing.id);
+            puzzleId = existing.id;
+            const count = db.prepare("SELECT COUNT(*) as c FROM sectors WHERE puzzle_id = ?").get(puzzleId).c;
+            if (count === 0) seedSectors(db, puzzleId, startNorm, endNorm);
         } else {
-            db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 1)")
-                .run(name, startNorm, endNorm);
+            // New puzzle or changed range — create a new row so old chunk history is preserved
+            const info = db.prepare(
+                "INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 1)"
+            ).run(name, startNorm, endNorm);
+            puzzleId = info.lastInsertRowid;
+            seedSectors(db, puzzleId, startNorm, endNorm);
         }
     })();
 
@@ -373,7 +448,7 @@ app.post('/api/v1/admin/set-puzzle', (req, res) => {
     res.json({ ok: true, puzzle });
 });
 
-// 5. Admin: set (or clear) a test chunk on the active puzzle
+// 5b. Admin: set (or clear) a test chunk on the active puzzle
 // POST /api/v1/admin/set-test-chunk
 // Body: { start_hex, end_hex }  — set a test chunk
 //       { start_hex: null }     — clear the test chunk
@@ -463,6 +538,17 @@ if (require.main === module) {
         found_address TEXT
       );
       CREATE INDEX IF NOT EXISTS idx_chunks_puzzle_status ON chunks (puzzle_id, status);
+      CREATE TABLE IF NOT EXISTS sectors (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        puzzle_id   INTEGER NOT NULL,
+        start_hex   TEXT NOT NULL,
+        end_hex     TEXT NOT NULL,
+        current_hex TEXT NOT NULL,
+        status      TEXT NOT NULL DEFAULT 'open'
+      );
+      CREATE INDEX IF NOT EXISTS idx_sectors_puzzle_status ON sectors (puzzle_id, status);
+      CREATE INDEX IF NOT EXISTS idx_sectors_puzzle_id     ON sectors (puzzle_id, id);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_sectors_unique_span ON sectors (puzzle_id, start_hex, end_hex);
       CREATE TABLE IF NOT EXISTS findings (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         chunk_id INTEGER NOT NULL,
@@ -489,20 +575,24 @@ if (require.main === module) {
         const endNorm   = endRaw.replace(/^0x/i, '').padStart(64, '0').toLowerCase();
         const existing  = db.prepare("SELECT id FROM puzzles WHERE name = ?").get(name);
         if (!existing) {
-            db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 0)")
+            const info = db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 0)")
                 .run(name, startNorm, endNorm);
             console.log(`[Config] Seeded keyspace: ${name}`);
+            seedSectors(db, info.lastInsertRowid, startNorm, endNorm);
         }
     }
 
     // Fall back to built-in Puzzle #71 if DB is still empty
     const puzzleCount = db.prepare("SELECT COUNT(*) as count FROM puzzles").get().count;
     if (puzzleCount === 0) {
-        db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 1)")
+        const info = db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 1)")
             .run('Puzzle #71',
                 '0400000000000000000'.padStart(64, '0'),
                 '07fffffffffffffffff'.padStart(64, '0'));
         console.log('[Init] Seeded Puzzle #71 as active puzzle.');
+        seedSectors(db, info.lastInsertRowid,
+            '0400000000000000000'.padStart(64, '0'),
+            '07fffffffffffffffff'.padStart(64, '0'));
     }
 
     // Ensure exactly one puzzle is active
@@ -510,6 +600,15 @@ if (require.main === module) {
     if (activeCount === 0) {
         db.prepare("UPDATE puzzles SET active = 1 WHERE id = (SELECT MIN(id) FROM puzzles)").run();
         console.log('[Init] No active puzzle found — activated the first one.');
+    }
+
+    // Seed sectors for any existing puzzle that doesn't have them yet (migration path)
+    const unsectored = db.prepare(`
+        SELECT p.id, p.start_hex, p.end_hex FROM puzzles p
+        WHERE NOT EXISTS (SELECT 1 FROM sectors s WHERE s.puzzle_id = p.id)
+    `).all();
+    for (const p of unsectored) {
+        seedSectors(db, p.id, p.start_hex, p.end_hex);
     }
 
     const app = createApp(db);
@@ -533,4 +632,4 @@ if (require.main === module) {
     });
 }
 
-module.exports = { createApp, isValidHex, randomBigIntInRange };
+module.exports = { createApp, isValidHex, randomBigIntInRange, seedSectors };

--- a/server.js
+++ b/server.js
@@ -231,6 +231,7 @@ app.post('/api/v1/work', (req, res) => {
 app.post('/api/v1/submit', (req, res) => {
     const { name, job_id, status, found_key, found_address } = req.body;
     if (status !== "done" && status !== "FOUND") return res.status(400).json({ error: 'status must be "done" or "FOUND"' });
+    if (status === "FOUND" && !found_key) return res.status(400).json({ error: 'found_key is required when status is "FOUND"' });
 
     if (status === "FOUND") {
         // Update chunk first (status guard prevents invalid transitions from non-assigned rows).
@@ -240,12 +241,12 @@ app.post('/api/v1/submit', (req, res) => {
         ).run(found_key, found_address || null, job_id, name);
 
         if (!info.changes) {
-            // Idempotency: if this exact finding was already recorded (e.g. client retry),
-            // accept silently without writing anything again.
-            const already = db.prepare(
+            // Idempotency: if this exact finding is already recorded (e.g. client retry
+            // after chunk was finalized by the first attempt), accept silently.
+            const alreadyRecorded = db.prepare(
                 "SELECT id FROM findings WHERE chunk_id = ? AND worker_name = ? AND found_key = ?"
             ).get(job_id, name, found_key);
-            if (already) return res.json({ accepted: true });
+            if (alreadyRecorded) return res.json({ accepted: true });
 
             // Late FOUND: chunk was reclaimed/reassigned before submission. Accept only if
             // this worker was the previous legitimate assignee and the chunk is still
@@ -265,14 +266,19 @@ app.post('/api/v1/submit', (req, res) => {
             console.log(`[Late FOUND] Job: ${job_id} | Worker: ${name} (prev assignee) | KEY: ${found_key}`);
         }
 
-        const msg = `[${new Date().toISOString()}] BINGO! Job: ${job_id} | Worker: ${name} | KEY: ${found_key} | ADDR: ${found_address || 'Unknown'}\n`;
-        console.log(`\n🚨🚨🚨 ${msg}`);
-        fs.appendFileSync('BINGO_FOUND_KEYS.txt', msg);
-
+        // INSERT OR IGNORE + unique index on (chunk_id, worker_name, found_key) makes
+        // dedup atomic — concurrent retries cannot both insert, and the BINGO log is
+        // only written when the insert actually claimed the row.
         // findings rows are not marked is_test; test vs production is distinguished by
         // joining to chunks.is_test. /stats already filters with AND c.is_test = 0.
-        db.prepare("INSERT INTO findings (chunk_id, worker_name, found_key, found_address) VALUES (?, ?, ?, ?)")
+        const findingInfo = db.prepare("INSERT OR IGNORE INTO findings (chunk_id, worker_name, found_key, found_address) VALUES (?, ?, ?, ?)")
             .run(job_id, name, found_key, found_address || null);
+
+        if (findingInfo.changes) {
+            const msg = `[${new Date().toISOString()}] BINGO! Job: ${job_id} | Worker: ${name} | KEY: ${found_key} | ADDR: ${found_address || 'Unknown'}\n`;
+            console.log(`\n🚨🚨🚨 ${msg}`);
+            fs.appendFileSync('BINGO_FOUND_KEYS.txt', msg);
+        }
     } else {
         const info = db.prepare("UPDATE chunks SET status = 'completed' WHERE id = ? AND worker_name = ? AND status = 'assigned'")
             .run(job_id, name);
@@ -629,12 +635,14 @@ if (require.main === module) {
         found_address TEXT,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
       );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_findings_dedup ON findings (chunk_id, worker_name, found_key);
     `);
 
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_start_hex TEXT").run(); } catch (_) {}
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_end_hex   TEXT").run(); } catch (_) {}
     try { db.prepare("ALTER TABLE chunks ADD COLUMN is_test         INTEGER NOT NULL DEFAULT 0").run(); } catch (_) {}
     try { db.prepare("ALTER TABLE chunks ADD COLUMN prev_worker_name TEXT").run(); } catch (_) {}
+    try { db.prepare("CREATE UNIQUE INDEX IF NOT EXISTS idx_findings_dedup ON findings (chunk_id, worker_name, found_key)").run(); } catch (_) {}
     // Best-effort backfill — runs every boot (idempotent). Marks chunks whose range exactly
     // matches the puzzle's current test_start_hex/test_end_hex as is_test=1. Chunks from
     // previously-used test ranges that no longer match cannot be recovered automatically;

--- a/server.js
+++ b/server.js
@@ -239,16 +239,28 @@ app.post('/api/v1/submit', (req, res) => {
         ).run(found_key, found_address || null, job_id, name);
 
         if (!info.changes) {
-            // Late FOUND: chunk was reclaimed/reassigned before submission. Accept if this
-            // worker was the previous legitimate assignee so the key is never lost.
-            // Only accept late FOUND while the chunk is still in-progress (assigned to
-            // someone else or reclaimed). Reject if already finalized (FOUND/completed)
-            // to prevent duplicate accepted winners on the same chunk.
-            const wasPrev = db.prepare(
-                "SELECT id FROM chunks WHERE id = ? AND prev_worker_name = ? AND status IN ('assigned', 'reclaimed')"
+            // Idempotency: if this exact finding was already recorded (e.g. client retry),
+            // accept silently without writing anything again.
+            const already = db.prepare(
+                "SELECT id FROM findings WHERE chunk_id = ? AND worker_name = ? AND found_key = ?"
+            ).get(job_id, name, found_key);
+            if (already) return res.json({ accepted: true });
+
+            // Late FOUND: chunk was reclaimed/reassigned before submission. Accept only if
+            // this worker was the previous legitimate assignee and the chunk is still
+            // in-progress (not yet finalized), to prevent duplicate accepted winners.
+            const latePrev = db.prepare(
+                "SELECT id, status FROM chunks WHERE id = ? AND prev_worker_name = ? AND status IN ('assigned', 'reclaimed')"
             ).get(job_id, name);
-            if (!wasPrev) return res.json({ accepted: false });
-            // Chunk now belongs to another worker — log the key but leave chunk status alone.
+            if (!latePrev) return res.json({ accepted: false });
+
+            if (latePrev.status === 'reclaimed') {
+                // Chunk belongs to nobody — claim it as FOUND so it leaves circulation.
+                db.prepare(
+                    "UPDATE chunks SET status = 'FOUND', worker_name = ?, found_key = COALESCE(found_key, ?), found_address = COALESCE(found_address, ?) WHERE id = ?"
+                ).run(name, found_key, found_address || null, job_id);
+            }
+            // If status is 'assigned' the chunk belongs to another worker — leave it alone.
             console.log(`[Late FOUND] Job: ${job_id} | Worker: ${name} (prev assignee) | KEY: ${found_key}`);
         }
 

--- a/server.js
+++ b/server.js
@@ -238,7 +238,16 @@ app.post('/api/v1/submit', (req, res) => {
             "UPDATE chunks SET status = 'FOUND', found_key = COALESCE(found_key, ?), found_address = COALESCE(found_address, ?) WHERE id = ? AND worker_name = ? AND status = 'assigned'"
         ).run(found_key, found_address || null, job_id, name);
 
-        if (!info.changes) return res.json({ accepted: false });
+        if (!info.changes) {
+            // Late FOUND: chunk was reclaimed/reassigned before submission. Accept if this
+            // worker was the previous legitimate assignee so the key is never lost.
+            const wasPrev = db.prepare(
+                "SELECT id FROM chunks WHERE id = ? AND prev_worker_name = ?"
+            ).get(job_id, name);
+            if (!wasPrev) return res.json({ accepted: false });
+            // Chunk now belongs to another worker — log the key but leave chunk status alone.
+            console.log(`[Late FOUND] Job: ${job_id} | Worker: ${name} (prev assignee) | KEY: ${found_key}`);
+        }
 
         const msg = `[${new Date().toISOString()}] BINGO! Job: ${job_id} | Worker: ${name} | KEY: ${found_key} | ADDR: ${found_address || 'Unknown'}\n`;
         console.log(`\n🚨🚨🚨 ${msg}`);
@@ -578,6 +587,7 @@ if (require.main === module) {
         end_hex TEXT,
         status TEXT,
         worker_name TEXT,
+        prev_worker_name TEXT,
         assigned_at DATETIME,
         found_key TEXT,
         found_address TEXT,
@@ -607,7 +617,8 @@ if (require.main === module) {
 
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_start_hex TEXT").run(); } catch (_) {}
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_end_hex   TEXT").run(); } catch (_) {}
-    try { db.prepare("ALTER TABLE chunks ADD COLUMN is_test INTEGER NOT NULL DEFAULT 0").run(); } catch (_) {}
+    try { db.prepare("ALTER TABLE chunks ADD COLUMN is_test         INTEGER NOT NULL DEFAULT 0").run(); } catch (_) {}
+    try { db.prepare("ALTER TABLE chunks ADD COLUMN prev_worker_name TEXT").run(); } catch (_) {}
     // Best-effort backfill — runs every boot (idempotent). Marks chunks whose range exactly
     // matches the puzzle's current test_start_hex/test_end_hex as is_test=1. Chunks from
     // previously-used test ranges that no longer match cannot be recovered automatically;
@@ -688,7 +699,7 @@ if (require.main === module) {
     setInterval(() => {
         const info = db.prepare(`
             UPDATE chunks
-            SET status = 'reclaimed', worker_name = NULL
+            SET status = 'reclaimed', prev_worker_name = worker_name, worker_name = NULL
             WHERE status = 'assigned'
             AND assigned_at < datetime('now', '-${TIMEOUT_MINUTES} minutes')
         `).run();

--- a/server.js
+++ b/server.js
@@ -82,8 +82,8 @@ function createApp(db) {
     const stmtInsertChunk     = db.prepare("INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at, is_test) VALUES (?, ?, ?, 'assigned', ?, CURRENT_TIMESTAMP, 0)");
     // Both taken/reclaim queries match on start_hex + end_hex + is_test = 1 so a different
     // test chunk with the same start but different end cannot interfere.
-    // Only 'assigned' counts as taken — completed/FOUND rows do not block reissue, so admins
-    // can rerun the same test range without manual DB cleanup.
+    // Only 'assigned' blocks reissue. After a successful submit the test config is
+    // auto-cleared, so a rerun requires the admin to call set-test-chunk again.
     const stmtTestChunkTaken  = db.prepare("SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND end_hex = ? AND is_test = 1 AND status = 'assigned' LIMIT 1");
     const stmtTestChunkReclaim = db.prepare(`
         UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
@@ -136,8 +136,8 @@ function createApp(db) {
     // Test chunk claiming — IMMEDIATE transaction to prevent two concurrent requests
     // from both passing the "not yet taken" check before either inserts.
     // is_test = 1 is set on insert so these rows are excluded from puzzle stats.
-    // Only an 'assigned' row blocks reissue; completed/FOUND rows do not, so the admin
-    // can rerun the exact same test range without any DB cleanup.
+    // Reissue is blocked only while status = 'assigned'; after completion the test
+    // config is auto-cleared so a rerun requires the admin to call set-test-chunk again.
     const claimTestChunk = db.transaction((name, puzzle) => {
         const taken = stmtTestChunkTaken.get(puzzle.id, puzzle.test_start_hex, puzzle.test_end_hex);
         if (taken) return null;
@@ -259,9 +259,9 @@ app.post('/api/v1/submit', (req, res) => {
     // arrives is not accidentally erased.
     const chunk = db.prepare("SELECT is_test, puzzle_id, start_hex, end_hex FROM chunks WHERE id = ?").get(job_id);
     if (chunk?.is_test) {
-        db.prepare("UPDATE puzzles SET test_start_hex = NULL, test_end_hex = NULL WHERE id = ? AND test_start_hex = ? AND test_end_hex = ?")
+        const cleared = db.prepare("UPDATE puzzles SET test_start_hex = NULL, test_end_hex = NULL WHERE id = ? AND test_start_hex = ? AND test_end_hex = ?")
             .run(chunk.puzzle_id, chunk.start_hex, chunk.end_hex);
-        console.log(`[Test] Test chunk #${job_id} completed — test config cleared from puzzle ${chunk.puzzle_id}`);
+        if (cleared.changes) console.log(`[Test] Test chunk #${job_id} completed — test config cleared from puzzle ${chunk.puzzle_id}`);
     }
 
     res.json({ accepted: true });

--- a/server.js
+++ b/server.js
@@ -710,7 +710,11 @@ if (require.main === module) {
 
     const app = createApp(db);
 
-    // Background reclaim task
+    // Background reclaim task.
+    // NOTE: prev_worker_name retains only the most recent prior assignee. If the same
+    // chunk is reclaimed and reassigned multiple times, only the latest previous owner
+    // can be verified for a late FOUND. Full provenance would require an assignment
+    // history table; that is a known limitation of this single-slot design.
     setInterval(() => {
         const info = db.prepare(`
             UPDATE chunks

--- a/server.js
+++ b/server.js
@@ -642,6 +642,7 @@ if (require.main === module) {
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_end_hex   TEXT").run(); } catch (_) {}
     try { db.prepare("ALTER TABLE chunks ADD COLUMN is_test         INTEGER NOT NULL DEFAULT 0").run(); } catch (_) {}
     try { db.prepare("ALTER TABLE chunks ADD COLUMN prev_worker_name TEXT").run(); } catch (_) {}
+    // Migration path for DBs created before idx_findings_dedup was added.
     try { db.prepare("CREATE UNIQUE INDEX IF NOT EXISTS idx_findings_dedup ON findings (chunk_id, worker_name, found_key)").run(); } catch (_) {}
     // Best-effort backfill — runs every boot (idempotent). Marks chunks whose range exactly
     // matches the puzzle's current test_start_hex/test_end_hex as is_test=1. Chunks from

--- a/server.js
+++ b/server.js
@@ -230,6 +230,7 @@ app.post('/api/v1/work', (req, res) => {
 // 2. Submit Results
 app.post('/api/v1/submit', (req, res) => {
     const { name, job_id, status, found_key, found_address } = req.body;
+    if (status !== "done" && status !== "FOUND") return res.status(400).json({ error: 'status must be "done" or "FOUND"' });
 
     if (status === "FOUND") {
         // Update chunk first (status guard prevents invalid transitions from non-assigned rows).

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ function isValidHex(s) {
     return /^(0x)?[0-9a-fA-F]+$/.test(s);
 }
 
+// Exported for consumers that need arbitrary-range random sampling.
 // Generate a uniformly random BigInt in [min, max) with negligible bias.
 function randomBigIntInRange(min, max) {
     const range = max - min;
@@ -27,6 +28,14 @@ function randomBigIntInRange(min, max) {
     const bytes = crypto.randomBytes(byteLen);
     const n = BigInt('0x' + bytes.toString('hex'));
     return min + (n % range);
+}
+
+// Coerce any client-supplied hashrate to a safe positive BigInt.
+// Returns BigInt(fallback) for NaN, Infinity, negative, zero, or non-numeric input.
+function normalizeHashrate(input, fallback = 1_000_000) {
+    const n = Number(input);
+    if (!Number.isFinite(n) || n <= 0) return BigInt(fallback);
+    return BigInt(Math.max(1, Math.floor(n)));
 }
 
 // Divide puzzle keyspace into sectors with independent frontiers.
@@ -65,49 +74,75 @@ function seedSectors(db, puzzleId, startHex, endHex) {
 // --- App factory (accepts db for testability) ---
 
 function createApp(db) {
-    // Assign the next chunk from the sector frontier.
-    // Uses BEGIN IMMEDIATE so the write lock is acquired before the SELECT read,
-    // preventing two concurrent connections from observing the same open sector.
-    // Returns null when all sectors are exhausted (caller should respond 503).
-    // ORDER BY RANDOM() is a deliberate tradeoff — acceptable at ≤65,536 rows.
-    const assignRandomChunk = db.transaction((name, hashrate, puzzle) => {
-        const sector = db.prepare(
-            "SELECT * FROM sectors WHERE puzzle_id = ? AND status = 'open' ORDER BY RANDOM() LIMIT 1"
-        ).get(puzzle.id);
-        if (!sector) return null;
+    // Prepared statements hoisted here so they are compiled once, not on every request.
+    const stmtOpenSector    = db.prepare("SELECT * FROM sectors WHERE puzzle_id = ? AND status = 'open' ORDER BY RANDOM() LIMIT 1");
+    const stmtWorkerHash    = db.prepare("SELECT hashrate FROM workers WHERE name = ?");
+    const stmtSectorDone    = db.prepare("UPDATE sectors SET current_hex = end_hex, status = 'done' WHERE id = ?");
+    const stmtSectorAdvance = db.prepare("UPDATE sectors SET current_hex = ? WHERE id = ?");
+    const stmtInsertChunk   = db.prepare("INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at) VALUES (?, ?, ?, 'assigned', ?, CURRENT_TIMESTAMP)");
 
-        const stored      = db.prepare("SELECT hashrate FROM workers WHERE name = ?").get(name);
-        const hashrateBig = BigInt(Math.floor(hashrate || stored?.hashrate || 1_000_000));
+    // Fresh allocation from sector frontier.
+    // BEGIN IMMEDIATE acquires the write lock before the SELECT so two concurrent
+    // connections cannot observe the same open sector. ORDER BY RANDOM() over
+    // ≤65,536 rows is a deliberate tradeoff. Returns null only when all sectors
+    // are exhausted; stale open sectors (effective=0) are cleaned up and retried.
+    const assignRandomChunk = db.transaction((name, hashrate, puzzle) => {
+        const hashrateBig = normalizeHashrate(hashrate || stmtWorkerHash.get(name)?.hashrate);
         const chunkSize   = hashrateBig * BigInt(TARGET_MINUTES * 60);
 
-        const current   = BigInt('0x' + sector.current_hex);
-        const sectorEnd = BigInt('0x' + sector.end_hex);
-        const effective = chunkSize < (sectorEnd - current) ? chunkSize : (sectorEnd - current);
+        for (;;) {
+            const sector = stmtOpenSector.get(puzzle.id);
+            if (!sector) return null;
 
-        // Defensive guard: sector should not be open with no space remaining
-        if (effective <= 0n) {
-            db.prepare("UPDATE sectors SET current_hex = end_hex, status = 'done' WHERE id = ?")
-                .run(sector.id);
-            return null;
+            const current   = BigInt('0x' + sector.current_hex);
+            const sectorEnd = BigInt('0x' + sector.end_hex);
+            const effective = chunkSize < (sectorEnd - current) ? chunkSize : (sectorEnd - current);
+
+            if (effective <= 0n) {
+                // Stale open sector — clean up and try another
+                stmtSectorDone.run(sector.id);
+                continue;
+            }
+
+            const startHex = current.toString(16).padStart(64, '0');
+            const endHex   = (current + effective).toString(16).padStart(64, '0');
+
+            if (current + effective >= sectorEnd) {
+                stmtSectorDone.run(sector.id);
+            } else {
+                stmtSectorAdvance.run(endHex, sector.id);
+            }
+
+            const info = stmtInsertChunk.run(puzzle.id, startHex, endHex, name);
+            return { chunkId: info.lastInsertRowid, startHex, endHex };
         }
+    });
 
-        const startHex = current.toString(16).padStart(64, '0');
-        const endHex   = (current + effective).toString(16).padStart(64, '0');
+    // Test chunk claiming — IMMEDIATE transaction to prevent two concurrent requests
+    // from both passing the "not yet taken" check before either inserts.
+    const claimTestChunk = db.transaction((name, puzzle) => {
+        const taken = db.prepare(`
+            SELECT id FROM chunks
+            WHERE puzzle_id = ? AND start_hex = ?
+              AND status IN ('assigned', 'completed', 'FOUND')
+            LIMIT 1
+        `).get(puzzle.id, puzzle.test_start_hex);
+        if (taken) return null;
 
-        if (current + effective >= sectorEnd) {
-            db.prepare("UPDATE sectors SET current_hex = end_hex, status = 'done' WHERE id = ?")
-                .run(sector.id);
-        } else {
-            db.prepare("UPDATE sectors SET current_hex = ? WHERE id = ?")
-                .run(endHex, sector.id);
-        }
+        const reclaimed = db.prepare(`
+            UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
+            WHERE id = (
+                SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND status = 'reclaimed' LIMIT 1
+            )
+            RETURNING *
+        `).get(name, puzzle.id, puzzle.test_start_hex);
+        if (reclaimed) return reclaimed;
 
-        const info = db.prepare(`
+        return db.prepare(`
             INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at)
             VALUES (?, ?, ?, 'assigned', ?, CURRENT_TIMESTAMP)
-        `).run(puzzle.id, startHex, endHex, name);
-
-        return { chunkId: info.lastInsertRowid, startHex, endHex };
+            RETURNING *
+        `).get(puzzle.id, puzzle.test_start_hex, puzzle.test_end_hex, name);
     });
 
     const app = express();
@@ -147,49 +182,12 @@ app.post('/api/v1/work', (req, res) => {
 
     let chunkId, startHex, endHex;
 
-    // PRIORITY 1: Test chunk — assign it to the very first requester if not yet taken.
-    // "Not yet taken" means no chunk row with this exact start_hex exists in
-    // assigned/completed/FOUND state. Reclaimed test chunks are reissued normally below.
+    // PRIORITY 1: Test chunk — atomic IMMEDIATE claim; only one worker ever receives it.
     if (puzzle.test_start_hex && puzzle.test_end_hex) {
-        const testTaken = db.prepare(`
-            SELECT id FROM chunks
-            WHERE puzzle_id = ? AND start_hex = ?
-              AND status IN ('assigned', 'completed', 'FOUND')
-            LIMIT 1
-        `).get(puzzle.id, puzzle.test_start_hex);
-
-        if (!testTaken) {
-            // Check if it was previously reclaimed — reuse that row rather than inserting a new one
-            const testReclaimed = db.prepare(`
-                SELECT * FROM chunks
-                WHERE puzzle_id = ? AND start_hex = ? AND status = 'reclaimed'
-                LIMIT 1
-            `).get(puzzle.id, puzzle.test_start_hex);
-
-            if (testReclaimed) {
-                const assigned = db.prepare(`
-                    UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
-                    WHERE id = (
-                        SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND status = 'reclaimed' LIMIT 1
-                    )
-                    RETURNING *
-                `).get(name, puzzle.id, puzzle.test_start_hex);
-                if (!assigned) return res.status(503).json({ error: "No work available" });
-                chunkId  = assigned.id;
-                startHex = assigned.start_hex;
-                endHex   = assigned.end_hex;
-            } else {
-                startHex = puzzle.test_start_hex;
-                endHex   = puzzle.test_end_hex;
-                const info = db.prepare(`
-                    INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at)
-                    VALUES (?, ?, ?, 'assigned', ?, CURRENT_TIMESTAMP)
-                `).run(puzzle.id, startHex, endHex, name);
-                chunkId = info.lastInsertRowid;
-            }
-
-            console.log(`[Test] Assigned test chunk #${chunkId} to ${name}`);
-            return res.json({ job_id: chunkId, start_key: startHex, end_key: endHex });
+        const claimed = claimTestChunk.immediate(name, puzzle);
+        if (claimed) {
+            console.log(`[Test] Assigned test chunk #${claimed.id} to ${name}`);
+            return res.json({ job_id: claimed.id, start_key: claimed.start_hex, end_key: claimed.end_hex });
         }
     }
 
@@ -459,7 +457,6 @@ app.post('/api/v1/admin/set-test-chunk', (req, res) => {
     const { start_hex, end_hex } = req.body;
 
     if (!start_hex) {
-        // Clear
         db.prepare("UPDATE puzzles SET test_start_hex = NULL, test_end_hex = NULL WHERE id = ?")
             .run(puzzle.id);
         console.log(`[Admin] Test chunk cleared for puzzle ${puzzle.name}`);
@@ -473,6 +470,18 @@ app.post('/api/v1/admin/set-test-chunk', (req, res) => {
 
     const startNorm = start_hex.replace(/^0x/i, '').padStart(64, '0').toLowerCase();
     const endNorm   = end_hex.replace(/^0x/i, '').padStart(64, '0').toLowerCase();
+
+    const ts = BigInt('0x' + startNorm);
+    const te = BigInt('0x' + endNorm);
+    const ps = BigInt('0x' + puzzle.start_hex);
+    const pe = BigInt('0x' + puzzle.end_hex);
+
+    if (te <= ts) {
+        return res.status(400).json({ error: "end_hex must be greater than start_hex" });
+    }
+    if (ts < ps || te > pe) {
+        return res.status(400).json({ error: "Test chunk must lie within active puzzle range" });
+    }
 
     db.prepare("UPDATE puzzles SET test_start_hex = ?, test_end_hex = ? WHERE id = ?")
         .run(startNorm, endNorm, puzzle.id);
@@ -493,6 +502,10 @@ app.post('/api/v1/admin/set-test-chunk', (req, res) => {
             db.prepare("UPDATE puzzles SET active = 0").run();
             db.prepare("UPDATE puzzles SET active = 1 WHERE id = ?").run(id);
         })();
+
+        // Seed sectors lazily if this puzzle has none (e.g. imported rows, pre-migration data)
+        const sectorCount = db.prepare("SELECT COUNT(*) as c FROM sectors WHERE puzzle_id = ?").get(id).c;
+        if (sectorCount === 0) seedSectors(db, target.id, target.start_hex, target.end_hex);
 
         const puzzle = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(id);
         console.log(`[Admin] Active puzzle switched to: ${puzzle.name}`);
@@ -573,6 +586,10 @@ if (require.main === module) {
         }
         const startNorm = startRaw.replace(/^0x/i, '').padStart(64, '0').toLowerCase();
         const endNorm   = endRaw.replace(/^0x/i, '').padStart(64, '0').toLowerCase();
+        if (BigInt('0x' + endNorm) <= BigInt('0x' + startNorm)) {
+            console.warn(`[Config] Skipping ${key} — end_hex must be greater than start_hex`);
+            continue;
+        }
         const existing  = db.prepare("SELECT id FROM puzzles WHERE name = ?").get(name);
         if (!existing) {
             const info = db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 0)")
@@ -595,11 +612,14 @@ if (require.main === module) {
             '07fffffffffffffffff'.padStart(64, '0'));
     }
 
-    // Ensure exactly one puzzle is active
+    // Ensure exactly one puzzle is active (normalize both zero and multiple active)
     const activeCount = db.prepare("SELECT COUNT(*) as count FROM puzzles WHERE active = 1").get().count;
     if (activeCount === 0) {
         db.prepare("UPDATE puzzles SET active = 1 WHERE id = (SELECT MIN(id) FROM puzzles)").run();
         console.log('[Init] No active puzzle found — activated the first one.');
+    } else if (activeCount > 1) {
+        db.prepare("UPDATE puzzles SET active = 0 WHERE id != (SELECT MAX(id) FROM puzzles WHERE active = 1)").run();
+        console.log('[Init] Multiple active puzzles found — deactivated all but the latest.');
     }
 
     // Seed sectors for any existing puzzle that doesn't have them yet (migration path)
@@ -632,4 +652,4 @@ if (require.main === module) {
     });
 }
 
-module.exports = { createApp, isValidHex, randomBigIntInRange, seedSectors };
+module.exports = { createApp, isValidHex, randomBigIntInRange, normalizeHashrate, seedSectors };

--- a/server.js
+++ b/server.js
@@ -82,7 +82,9 @@ function createApp(db) {
     const stmtInsertChunk     = db.prepare("INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at, is_test) VALUES (?, ?, ?, 'assigned', ?, CURRENT_TIMESTAMP, 0)");
     // Both taken/reclaim queries match on start_hex + end_hex + is_test = 1 so a different
     // test chunk with the same start but different end cannot interfere.
-    const stmtTestChunkTaken  = db.prepare("SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND end_hex = ? AND is_test = 1 AND status IN ('assigned', 'completed', 'FOUND') LIMIT 1");
+    // Only 'assigned' counts as taken — completed/FOUND rows do not block reissue, so admins
+    // can rerun the same test range without manual DB cleanup.
+    const stmtTestChunkTaken  = db.prepare("SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND end_hex = ? AND is_test = 1 AND status = 'assigned' LIMIT 1");
     const stmtTestChunkReclaim = db.prepare(`
         UPDATE chunks SET status = 'assigned', worker_name = ?, assigned_at = CURRENT_TIMESTAMP
         WHERE id = (SELECT id FROM chunks WHERE puzzle_id = ? AND start_hex = ? AND end_hex = ? AND is_test = 1 AND status = 'reclaimed' LIMIT 1)
@@ -134,10 +136,8 @@ function createApp(db) {
     // Test chunk claiming — IMMEDIATE transaction to prevent two concurrent requests
     // from both passing the "not yet taken" check before either inserts.
     // is_test = 1 is set on insert so these rows are excluded from puzzle stats.
-    // Completed/FOUND test chunks count as permanently taken; admins who want to rerun
-    // a test should call set-test-chunk again (even with the same range) — the next
-    // /work request will issue a fresh insert because the old row has a different end_hex
-    // or the taken check won't match a re-set range.
+    // Only an 'assigned' row blocks reissue; completed/FOUND rows do not, so the admin
+    // can rerun the exact same test range without any DB cleanup.
     const claimTestChunk = db.transaction((name, puzzle) => {
         const taken = stmtTestChunkTaken.get(puzzle.id, puzzle.test_start_hex, puzzle.test_end_hex);
         if (taken) return null;
@@ -171,7 +171,8 @@ app.post('/api/v1/work', (req, res) => {
     const { name, hashrate } = req.body;
     if (!name) return res.status(400).json({ error: "Missing name" });
 
-    // Upsert worker — store normalized hashrate so /stats sorting and totals are safe
+    // Upsert worker — normalize before storing. Number() loses precision above 2^53 but
+    // that range (~9 PH/s) is well beyond realistic hardware; acceptable tradeoff.
     const hashrateNum = Number(normalizeHashrate(hashrate));
     db.prepare(`
         INSERT INTO workers (name, hashrate, last_seen) VALUES (?, ?, CURRENT_TIMESTAMP)
@@ -228,6 +229,8 @@ app.post('/api/v1/submit', (req, res) => {
         console.log(`\n🚨🚨🚨 ${msg}`);
         fs.appendFileSync('BINGO_FOUND_KEYS.txt', msg);
 
+        // findings rows are not marked is_test; test vs production is distinguished by
+        // joining to chunks.is_test. /stats already filters with AND c.is_test = 0.
         db.prepare("INSERT INTO findings (chunk_id, worker_name, found_key, found_address) VALUES (?, ?, ?, ?)")
             .run(job_id, name, found_key, found_address || null);
 
@@ -581,12 +584,12 @@ if (require.main === module) {
 
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_start_hex TEXT").run(); } catch (_) {}
     try { db.prepare("ALTER TABLE puzzles ADD COLUMN test_end_hex   TEXT").run(); } catch (_) {}
-    // is_test defaults to 0 for all pre-existing rows. Best-effort backfill: mark any chunk
-    // whose range exactly matches the puzzle's current test_start_hex/test_end_hex as is_test=1.
-    // Chunks from previously-used test ranges that no longer match cannot be recovered
-    // automatically — manual cleanup is required for those rows if they cause stats noise.
+    try { db.prepare("ALTER TABLE chunks ADD COLUMN is_test INTEGER NOT NULL DEFAULT 0").run(); } catch (_) {}
+    // Best-effort backfill — runs every boot (idempotent). Marks chunks whose range exactly
+    // matches the puzzle's current test_start_hex/test_end_hex as is_test=1. Chunks from
+    // previously-used test ranges that no longer match cannot be recovered automatically;
+    // manual cleanup is required for those rows if they cause stats noise.
     try {
-        db.prepare("ALTER TABLE chunks ADD COLUMN is_test INTEGER NOT NULL DEFAULT 0").run();
         db.prepare(`
             UPDATE chunks SET is_test = 1
             WHERE is_test = 0

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -56,6 +56,7 @@ function createTestDb() {
             found_address TEXT,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
         );
+        CREATE UNIQUE INDEX idx_findings_dedup ON findings (chunk_id, worker_name, found_key);
     `);
 
     return db;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -33,6 +33,7 @@ function createTestDb() {
             end_hex TEXT,
             status TEXT,
             worker_name TEXT,
+            prev_worker_name TEXT,
             assigned_at DATETIME,
             found_key TEXT,
             found_address TEXT,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -35,7 +35,8 @@ function createTestDb() {
             worker_name TEXT,
             assigned_at DATETIME,
             found_key TEXT,
-            found_address TEXT
+            found_address TEXT,
+            is_test INTEGER NOT NULL DEFAULT 0
         );
         CREATE TABLE sectors (
             id          INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Database = require('better-sqlite3');
+const { seedSectors } = require('../server');
 
 /**
  * Create an in-memory SQLite database with the full puzzpool schema.
@@ -36,6 +37,15 @@ function createTestDb() {
             found_key TEXT,
             found_address TEXT
         );
+        CREATE TABLE sectors (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            puzzle_id   INTEGER NOT NULL,
+            start_hex   TEXT NOT NULL,
+            end_hex     TEXT NOT NULL,
+            current_hex TEXT NOT NULL,
+            status      TEXT NOT NULL DEFAULT 'open'
+        );
+        CREATE UNIQUE INDEX idx_sectors_unique_span ON sectors (puzzle_id, start_hex, end_hex);
         CREATE TABLE findings (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             chunk_id INTEGER NOT NULL,
@@ -50,15 +60,19 @@ function createTestDb() {
 }
 
 /**
- * Seed an active puzzle and return its row.
+ * Seed an active puzzle with sectors and return its row.
+ * Uses a range < MIN_SECTOR_SIZE (1B keys) so exactly 1 sector is created — fast for tests.
  */
 function seedPuzzle(db, opts = {}) {
     const name  = opts.name      || 'Test Puzzle';
-    const start = opts.start_hex || '0000000000000000000000000000000000000000000000000400000000000000';
-    const end   = opts.end_hex   || '0000000000000000000000000000000000000000000000007fffffffffffffff';
-    db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 1)")
+    const start = opts.start_hex || '0'.repeat(64);
+    // 0x3b9aca00 = 1,000,000,000 → range / MIN_SECTOR_SIZE = 1 sector
+    const end   = opts.end_hex   || '000000000000000000000000000000000000000000000000000000003b9aca00';
+    const info  = db.prepare("INSERT INTO puzzles (name, start_hex, end_hex, active) VALUES (?, ?, ?, 1)")
         .run(name, start, end);
-    return db.prepare("SELECT * FROM puzzles WHERE active = 1 LIMIT 1").get();
+    const puzzle = db.prepare("SELECT * FROM puzzles WHERE id = ?").get(info.lastInsertRowid);
+    seedSectors(db, puzzle.id, start, end);
+    return puzzle;
 }
 
 module.exports = { createTestDb, seedPuzzle };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -460,30 +460,28 @@ describe('Sharded Frontier Allocator', () => {
         expect(finding.found_key).toBe('deadbeef'.padStart(64, '0'));
     });
 
-    test('11b. late FOUND rejected after chunk already finalized (no duplicate winners)', async () => {
+    test('11b. late FOUND finalizes chunk even when currently assigned to another worker', async () => {
         seedPuzzle(db);
-        // Worker A gets chunk, is reclaimed
         const workA = await request(app).post('/api/v1/work').send({ name: 'workerA', hashrate: 1e9 }).expect(200);
         const jobId = workA.body.job_id;
+        // Reclaim and reassign to Worker B
         db.prepare("UPDATE chunks SET status = 'reclaimed', prev_worker_name = worker_name, worker_name = NULL WHERE id = ?").run(jobId);
+        await request(app).post('/api/v1/work').send({ name: 'workerB', hashrate: 1e9 }).expect(200);
 
-        // Worker B gets the same chunk (reissued) and submits FOUND first
-        const workB = await request(app).post('/api/v1/work').send({ name: 'workerB', hashrate: 1e9 }).expect(200);
-        expect(workB.body.job_id).toBe(jobId);
-        await request(app).post('/api/v1/submit')
-            .send({ name: 'workerB', job_id: jobId, status: 'FOUND', found_key: 'aabb'.padStart(64, '0'), found_address: '1Winner' })
-            .expect(200);
-
-        // Worker A submits late FOUND — must be rejected since chunk is already FOUND
+        // Worker A submits late FOUND while B holds it
         const late = await request(app).post('/api/v1/submit')
-            .send({ name: 'workerA', job_id: jobId, status: 'FOUND', found_key: 'ccdd'.padStart(64, '0'), found_address: '1Late' })
+            .send({ name: 'workerA', job_id: jobId, status: 'FOUND', found_key: 'aabb'.padStart(64, '0'), found_address: '1A' })
             .expect(200);
-        expect(late.body.accepted).toBe(false);
+        expect(late.body.accepted).toBe(true);
 
-        // Only one finding recorded (Worker B's)
-        const findings = db.prepare("SELECT * FROM findings WHERE chunk_id = ?").all(jobId);
-        expect(findings).toHaveLength(1);
-        expect(findings[0].worker_name).toBe('workerB');
+        // Chunk must be finalized — Worker B cannot now submit completed or FOUND
+        const chunk = db.prepare("SELECT status FROM chunks WHERE id = ?").get(jobId);
+        expect(chunk.status).toBe('FOUND');
+
+        const bSubmit = await request(app).post('/api/v1/submit')
+            .send({ name: 'workerB', job_id: jobId, status: 'done' })
+            .expect(200);
+        expect(bSubmit.body.accepted).toBe(false);
     });
 
     test('11c. late FOUND is idempotent — retries do not duplicate findings', async () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -275,6 +275,141 @@ describe('GET /api/v1/stats puzzles field', () => {
     });
 });
 
+// ─── Sharded Frontier Allocator ──────────────────────────────────────────────
+
+describe('Sharded Frontier Allocator', () => {
+    test('1. no-overlap: fresh assignments do not share any key', async () => {
+        seedPuzzle(db);
+        const chunks = [];
+        for (let i = 0; i < 3; i++) {
+            const r = await request(app).post('/api/v1/work').send({ name: `w${i}`, hashrate: 1000000 });
+            if (r.status === 200) chunks.push(r.body);
+        }
+        expect(chunks.length).toBe(3);
+        for (let i = 0; i < chunks.length; i++) {
+            for (let j = i + 1; j < chunks.length; j++) {
+                const aStart = BigInt('0x' + chunks[i].start_key);
+                const aEnd   = BigInt('0x' + chunks[i].end_key);
+                const bStart = BigInt('0x' + chunks[j].start_key);
+                const bEnd   = BigInt('0x' + chunks[j].end_key);
+                expect(aStart < bEnd && bStart < aEnd).toBe(false);
+            }
+        }
+    });
+
+    test('2. sector boundary: chunk capped at sector end, next starts exactly there', async () => {
+        // hashrate=1 → chunk = 1 × 5 × 60 = 300 keys; puzzle range = 1000 → 2 chunks fit
+        const end = (1000n).toString(16).padStart(64, '0');
+        seedPuzzle(db, { start_hex: '0'.repeat(64), end_hex: end });
+
+        const r1 = await request(app).post('/api/v1/work').send({ name: 'w1', hashrate: 1 });
+        const r2 = await request(app).post('/api/v1/work').send({ name: 'w2', hashrate: 1 });
+        expect(r1.status).toBe(200);
+        expect(r2.status).toBe(200);
+        expect(r1.body.start_key).toBe('0'.repeat(64));
+        expect(r2.body.start_key).toBe(r1.body.end_key);
+    });
+
+    test('3. exhaustion: 503 when all sectors are done', async () => {
+        // range=100 < 300 (chunk at hashrate=1) → first request covers entire sector
+        const end = (100n).toString(16).padStart(64, '0');
+        seedPuzzle(db, { start_hex: '0'.repeat(64), end_hex: end });
+
+        await request(app).post('/api/v1/work').send({ name: 'w1', hashrate: 1 }).expect(200);
+        const r = await request(app).post('/api/v1/work').send({ name: 'w2', hashrate: 1 });
+        expect(r.status).toBe(503);
+        expect(r.body.error).toMatch(/all keyspace/i);
+    });
+
+    test('4. reclaim priority: reclaimed chunk offered before fresh sector allocation', async () => {
+        seedPuzzle(db);
+        const puzzle = db.prepare("SELECT * FROM puzzles WHERE active=1").get();
+        const reclaimedInfo = db.prepare(`
+            INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name, assigned_at)
+            VALUES (?, ?, ?, 'reclaimed', NULL, CURRENT_TIMESTAMP)
+        `).run(puzzle.id, '0'.repeat(64), (1n).toString(16).padStart(64, '0'));
+
+        const r = await request(app).post('/api/v1/work').send({ name: 'w1', hashrate: 1000000 });
+        expect(r.body.job_id).toBe(reclaimedInfo.lastInsertRowid);
+
+        // Sector frontier must not have moved — reclaim took priority
+        const sector = db.prepare("SELECT * FROM sectors WHERE puzzle_id = ?").get(puzzle.id);
+        expect(sector.current_hex).toBe(sector.start_hex);
+    });
+
+    test('5. progress accounting: overlapping done chunks not double-counted', async () => {
+        seedPuzzle(db);
+        const puzzle = db.prepare("SELECT * FROM puzzles WHERE active=1").get();
+        // [0, 300) and [200, 500) → merged [0, 500) = 500 keys, not 600
+        const s1 = '0'.repeat(64);
+        const e1 = (300n).toString(16).padStart(64, '0');
+        const s2 = (200n).toString(16).padStart(64, '0');
+        const e2 = (500n).toString(16).padStart(64, '0');
+        db.prepare("INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name) VALUES (?, ?, ?, 'completed', 'w1')")
+            .run(puzzle.id, s1, e1);
+        db.prepare("INSERT INTO chunks (puzzle_id, start_hex, end_hex, status, worker_name) VALUES (?, ?, ?, 'completed', 'w2')")
+            .run(puzzle.id, s2, e2);
+
+        const stats = await request(app).get('/api/v1/stats');
+        expect(stats.body.total_keys_completed).toBe('500');
+    });
+
+    test('6. puzzle range change: creates new puzzle row, old data stays on old id', async () => {
+        await request(app).post('/api/v1/admin/set-puzzle')
+            .send({ name: 'P1', start_hex: '0x100', end_hex: '0x200' });
+        const p1 = db.prepare("SELECT * FROM puzzles WHERE active=1").get();
+        const p1Sectors = db.prepare("SELECT COUNT(*) as c FROM sectors WHERE puzzle_id=?").get(p1.id).c;
+        expect(p1Sectors).toBe(1);
+
+        // Change range → new puzzle row
+        await request(app).post('/api/v1/admin/set-puzzle')
+            .send({ name: 'P1', start_hex: '0x300', end_hex: '0x400' });
+        const p2 = db.prepare("SELECT * FROM puzzles WHERE active=1").get();
+
+        expect(p2.id).not.toBe(p1.id);
+        expect(p2.start_hex).toContain('3');   // normalized 0x300
+        const p2Sectors = db.prepare("SELECT COUNT(*) as c FROM sectors WHERE puzzle_id=?").get(p2.id).c;
+        expect(p2Sectors).toBe(1);
+        // Old row still exists and is inactive
+        const p1Row = db.prepare("SELECT * FROM puzzles WHERE id=?").get(p1.id);
+        expect(p1Row).toBeTruthy();
+        expect(p1Row.active).toBe(0);
+    });
+
+    test('7. consecutive allocations return non-overlapping sequential ranges', async () => {
+        seedPuzzle(db);
+        const r1 = await request(app).post('/api/v1/work').send({ name: 'w1', hashrate: 1000000 });
+        const r2 = await request(app).post('/api/v1/work').send({ name: 'w2', hashrate: 1000000 });
+        expect(r1.status).toBe(200);
+        expect(r2.status).toBe(200);
+        expect(r2.body.start_key).toBe(r1.body.end_key);
+    });
+
+    test('8. stats reset: new puzzle_id shows no chunks from previous range', async () => {
+        await request(app).post('/api/v1/admin/set-puzzle')
+            .send({ name: 'P1', start_hex: '0x100', end_hex: '0x200' });
+        const r = await request(app).post('/api/v1/work').send({ name: 'w1', hashrate: 1000000 });
+        await request(app).post('/api/v1/submit').send({ name: 'w1', job_id: r.body.job_id, status: 'done' });
+
+        // Change range → new puzzle row
+        await request(app).post('/api/v1/admin/set-puzzle')
+            .send({ name: 'P1', start_hex: '0x300', end_hex: '0x400' });
+
+        const stats = await request(app).get('/api/v1/stats');
+        expect(stats.body.total_keys_completed).toBe('0');
+        expect(stats.body.completed_chunks).toBe(0);
+    });
+
+    test('9. invalid range: set-puzzle rejects end_hex <= start_hex', async () => {
+        await request(app).post('/api/v1/admin/set-puzzle')
+            .send({ name: 'P1', start_hex: '0x200', end_hex: '0x200' })
+            .expect(400);
+        await request(app).post('/api/v1/admin/set-puzzle')
+            .send({ name: 'P1', start_hex: '0x300', end_hex: '0x100' })
+            .expect(400);
+    });
+});
+
 // ─── Admin: ADMIN_TOKEN auth ──────────────────────────────────────────────────
 
 describe('ADMIN_TOKEN middleware', () => {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -460,6 +460,32 @@ describe('Sharded Frontier Allocator', () => {
         expect(finding.found_key).toBe('deadbeef'.padStart(64, '0'));
     });
 
+    test('11b. late FOUND rejected after chunk already finalized (no duplicate winners)', async () => {
+        seedPuzzle(db);
+        // Worker A gets chunk, is reclaimed
+        const workA = await request(app).post('/api/v1/work').send({ name: 'workerA', hashrate: 1e9 }).expect(200);
+        const jobId = workA.body.job_id;
+        db.prepare("UPDATE chunks SET status = 'reclaimed', prev_worker_name = worker_name, worker_name = NULL WHERE id = ?").run(jobId);
+
+        // Worker B gets the same chunk (reissued) and submits FOUND first
+        const workB = await request(app).post('/api/v1/work').send({ name: 'workerB', hashrate: 1e9 }).expect(200);
+        expect(workB.body.job_id).toBe(jobId);
+        await request(app).post('/api/v1/submit')
+            .send({ name: 'workerB', job_id: jobId, status: 'FOUND', found_key: 'aabb'.padStart(64, '0'), found_address: '1Winner' })
+            .expect(200);
+
+        // Worker A submits late FOUND — must be rejected since chunk is already FOUND
+        const late = await request(app).post('/api/v1/submit')
+            .send({ name: 'workerA', job_id: jobId, status: 'FOUND', found_key: 'ccdd'.padStart(64, '0'), found_address: '1Late' })
+            .expect(200);
+        expect(late.body.accepted).toBe(false);
+
+        // Only one finding recorded (Worker B's)
+        const findings = db.prepare("SELECT * FROM findings WHERE chunk_id = ?").all(jobId);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].worker_name).toBe('workerB');
+    });
+
     test('12. FOUND rejected from worker with no provenance after reclaim', async () => {
         seedPuzzle(db);
         const work = await request(app).post('/api/v1/work').send({ name: 'workerA', hashrate: 1e9 }).expect(200);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -437,6 +437,47 @@ describe('Sharded Frontier Allocator', () => {
         expect(stats.body.scores).toHaveLength(0);
         expect(stats.body.chunks_vis).toHaveLength(0);
     });
+
+    test('11. late FOUND from previous assignee is accepted after reclaim', async () => {
+        seedPuzzle(db);
+        // Worker A gets a chunk
+        const work = await request(app).post('/api/v1/work').send({ name: 'workerA', hashrate: 1e9 }).expect(200);
+        const jobId = work.body.job_id;
+
+        // Simulate reclaim by directly updating the DB (background task not running in tests)
+        db.prepare("UPDATE chunks SET status = 'reclaimed', prev_worker_name = worker_name, worker_name = NULL WHERE id = ?")
+            .run(jobId);
+
+        // Worker A submits FOUND late (chunk no longer assigned to them)
+        const res = await request(app).post('/api/v1/submit')
+            .send({ name: 'workerA', job_id: jobId, status: 'FOUND', found_key: 'deadbeef'.padStart(64, '0'), found_address: '1Test' })
+            .expect(200);
+        expect(res.body.accepted).toBe(true);
+
+        // Finding should be recorded
+        const finding = db.prepare("SELECT * FROM findings WHERE chunk_id = ?").get(jobId);
+        expect(finding).toBeTruthy();
+        expect(finding.found_key).toBe('deadbeef'.padStart(64, '0'));
+    });
+
+    test('12. FOUND rejected from worker with no provenance after reclaim', async () => {
+        seedPuzzle(db);
+        const work = await request(app).post('/api/v1/work').send({ name: 'workerA', hashrate: 1e9 }).expect(200);
+        const jobId = work.body.job_id;
+
+        // Reclaim without any connection to workerB
+        db.prepare("UPDATE chunks SET status = 'reclaimed', prev_worker_name = worker_name, worker_name = NULL WHERE id = ?")
+            .run(jobId);
+
+        // Unrelated worker tries to submit FOUND
+        const res = await request(app).post('/api/v1/submit')
+            .send({ name: 'workerB', job_id: jobId, status: 'FOUND', found_key: 'deadbeef'.padStart(64, '0'), found_address: '1Test' })
+            .expect(200);
+        expect(res.body.accepted).toBe(false);
+
+        const finding = db.prepare("SELECT * FROM findings WHERE chunk_id = ?").get(jobId);
+        expect(finding).toBeUndefined();
+    });
 });
 
 // ─── Admin: ADMIN_TOKEN auth ──────────────────────────────────────────────────

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -486,6 +486,46 @@ describe('Sharded Frontier Allocator', () => {
         expect(findings[0].worker_name).toBe('workerB');
     });
 
+    test('11c. late FOUND is idempotent — retries do not duplicate findings', async () => {
+        seedPuzzle(db);
+        const work = await request(app).post('/api/v1/work').send({ name: 'workerA', hashrate: 1e9 }).expect(200);
+        const jobId = work.body.job_id;
+        db.prepare("UPDATE chunks SET status = 'reclaimed', prev_worker_name = worker_name, worker_name = NULL WHERE id = ?").run(jobId);
+
+        const key = 'cafe'.padStart(64, '0');
+        // First late FOUND
+        const r1 = await request(app).post('/api/v1/submit')
+            .send({ name: 'workerA', job_id: jobId, status: 'FOUND', found_key: key, found_address: '1A' })
+            .expect(200);
+        expect(r1.body.accepted).toBe(true);
+
+        // Retry — same request
+        const r2 = await request(app).post('/api/v1/submit')
+            .send({ name: 'workerA', job_id: jobId, status: 'FOUND', found_key: key, found_address: '1A' })
+            .expect(200);
+        expect(r2.body.accepted).toBe(true);
+
+        // Only one findings row
+        const findings = db.prepare("SELECT * FROM findings WHERE chunk_id = ?").all(jobId);
+        expect(findings).toHaveLength(1);
+    });
+
+    test('11d. late FOUND on reclaimed chunk transitions it to FOUND (removes from pool)', async () => {
+        seedPuzzle(db);
+        const work = await request(app).post('/api/v1/work').send({ name: 'workerA', hashrate: 1e9 }).expect(200);
+        const jobId = work.body.job_id;
+        db.prepare("UPDATE chunks SET status = 'reclaimed', prev_worker_name = worker_name, worker_name = NULL WHERE id = ?").run(jobId);
+
+        const res = await request(app).post('/api/v1/submit')
+            .send({ name: 'workerA', job_id: jobId, status: 'FOUND', found_key: 'beef'.padStart(64, '0'), found_address: '1B' })
+            .expect(200);
+        expect(res.body.accepted).toBe(true);
+
+        // Chunk must be FOUND now, not reclaimed
+        const chunk = db.prepare("SELECT status FROM chunks WHERE id = ?").get(jobId);
+        expect(chunk.status).toBe('FOUND');
+    });
+
     test('12. FOUND rejected from worker with no provenance after reclaim', async () => {
         seedPuzzle(db);
         const work = await request(app).post('/api/v1/work').send({ name: 'workerA', hashrate: 1e9 }).expect(200);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -408,6 +408,35 @@ describe('Sharded Frontier Allocator', () => {
             .send({ name: 'P1', start_hex: '0x300', end_hex: '0x100' })
             .expect(400);
     });
+
+    test('10. test chunks excluded from stats: completed_chunks, total_keys_completed, scores', async () => {
+        // Puzzle range: [0x0, 0x3b9aca00). Test chunk just above the puzzle range.
+        seedPuzzle(db);
+        const puzzle = db.prepare("SELECT * FROM puzzles WHERE active = 1 LIMIT 1").get();
+
+        // Set test chunk outside puzzle range
+        const testStart = '000000000000000000000000000000000000000000000000000000003b9aca00';
+        const testEnd   = '000000000000000000000000000000000000000000000000000000003b9acb00';
+        await request(app).post('/api/v1/admin/set-test-chunk')
+            .send({ start_hex: testStart, end_hex: testEnd })
+            .expect(200);
+
+        // Worker receives test chunk first
+        const work = await request(app).post('/api/v1/work').send({ name: 'tester', hashrate: 1e9 }).expect(200);
+        expect(work.body.start_key).toBe(testStart);
+
+        // Submit it as done
+        await request(app).post('/api/v1/submit')
+            .send({ name: 'tester', job_id: work.body.job_id, status: 'done' })
+            .expect(200);
+
+        // Stats must not reflect the test chunk
+        const stats = await request(app).get('/api/v1/stats').expect(200);
+        expect(stats.body.completed_chunks).toBe(0);
+        expect(stats.body.total_keys_completed).toBe('0');
+        expect(stats.body.scores).toHaveLength(0);
+        expect(stats.body.chunks_vis).toHaveLength(0);
+    });
 });
 
 // ─── Admin: ADMIN_TOKEN auth ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Replaces the random chunk allocator (Birthday Paradox overlaps) with a **sharded sector frontier** model. Fresh allocations are now guaranteed non-overlapping.

- **`sectors` table**: keyspace divided into up to 65,536 (2^16) sectors — 1:1 with heatmap/Hilbert canvas pixels. `numSectors` clamped to `[1, 65536]` with `MIN_SECTOR_SIZE = 1B` to prevent API spam on tiny puzzles.
- **`assignRandomChunk`**: picks a random open sector (`ORDER BY RANDOM()`), allocates `[current, current+chunk)`, advances the frontier — all in `BEGIN IMMEDIATE` to prevent concurrent connections grabbing the same sector.
- **`set-puzzle`**: validates `end_hex > start_hex`; creates a **new puzzle row** on range change so old chunk history stays attached to the old `puzzle_id` and `/stats` stays correct.
- **`/stats`**: interval merge retained for reclaimed-chunk reissue history (no longer needed for allocator overlaps).
- **Migration**: on startup, seeds sectors for any existing puzzle row that has none — live DB upgrade requires no manual reset.

## Test plan

- [x] All 33 tests pass (`npm test`) — 24 existing + 9 new
- [x] Test 1: no-overlap — fresh chunks never share a key
- [x] Test 2: sector boundary — chunk capped at sector end, next starts exactly there
- [x] Test 3: exhaustion — 503 "All keyspace has been assigned" when done
- [x] Test 4: reclaim priority — sector frontier not advanced when reclaimed chunk reissued
- [x] Test 5: progress accounting — overlapping done chunks not double-counted
- [x] Test 6: range change — new puzzle row created, old data preserved
- [x] Test 7: consecutive allocations — sequential, non-overlapping ranges
- [x] Test 8: stats reset — new puzzle_id shows zero completed chunks
- [x] Test 9: invalid range — `end_hex <= start_hex` → 400

Closes #17