### PR TITLE
fix: allow test chunk inside puzzle range

### DIFF
--- a/server.js
+++ b/server.js
@@ -539,12 +539,9 @@ app.post('/api/v1/admin/set-test-chunk', (req, res) => {
     if (te <= ts) {
         return res.status(400).json({ error: "end_hex must be greater than start_hex" });
     }
-    // Test chunks must lie OUTSIDE the active puzzle range so the sector allocator
-    // can never hand out the same keys as a fresh production chunk.
-    const overlaps = ts < pe && ps < te;
-    if (overlaps) {
-        return res.status(400).json({ error: "Test chunk must not overlap the active puzzle range" });
-    }
+    // Test chunks may overlap the puzzle range — that is the normal case (e.g. mid-keyspace
+    // verification). The sector allocator may later re-issue the same tiny range as a normal
+    // chunk; re-scanning a few million keys is harmless.
 
     db.prepare("UPDATE puzzles SET test_start_hex = ?, test_end_hex = ? WHERE id = ?")
         .run(startNorm, endNorm, puzzle.id);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -410,13 +410,12 @@ describe('Sharded Frontier Allocator', () => {
     });
 
     test('10. test chunks excluded from stats: completed_chunks, total_keys_completed, scores', async () => {
-        // Puzzle range: [0x0, 0x3b9aca00). Test chunk just above the puzzle range.
+        // Puzzle range: [0x0, 0x3b9aca00). Test chunk inside the puzzle range (mid-keyspace).
         seedPuzzle(db);
-        const puzzle = db.prepare("SELECT * FROM puzzles WHERE active = 1 LIMIT 1").get();
 
-        // Set test chunk outside puzzle range
-        const testStart = '000000000000000000000000000000000000000000000000000000003b9aca00';
-        const testEnd   = '000000000000000000000000000000000000000000000000000000003b9acb00';
+        // Set test chunk inside puzzle range — normal production setup
+        const testStart = '000000000000000000000000000000000000000000000000000000001dcde500';
+        const testEnd   = '000000000000000000000000000000000000000000000000000000001dcde600';
         await request(app).post('/api/v1/admin/set-test-chunk')
             .send({ start_hex: testStart, end_hex: testEnd })
             .expect(200);


### PR DESCRIPTION
## Summary

- Removes the erroneous constraint that required test chunks to lie **outside** the active puzzle range
- Shard #32768 (mid-keyspace verification) sits inside the puzzle range — the old guard would return 400
- Re-scanning the tiny test window later as a normal chunk is harmless
- Test 10 updated to place the test chunk inside the puzzle range, matching real production setup

## Test plan

- [x] 39/39 Jest tests pass
- [x] `POST /api/v1/admin/set-test-chunk` accepts a range inside the puzzle range
- [x] First `/work` request returns the test chunk; subsequent requests get normal chunks