### PR TITLE
feat: display in-shard chunk number in Visible Workers table (#37)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -139,7 +139,7 @@ Dashboard data — polled every 3 seconds by `index.html`.
   "reclaimed_chunks": 3,
   "total_keys_completed": "12345678901234567890",
   "workers": [
-    { "name": "rig1", "hashrate": 8000000, "last_seen": "2024-01-15 12:34:56", "version": "1.2.1", "active": true, "current_chunk": 42, "current_shard": 3 }
+    { "name": "rig1", "hashrate": 8000000, "last_seen": "2024-01-15 12:34:56", "version": "1.2.1", "active": true, "current_chunk": 42, "current_shard": 3, "current_chunk_in_shard": 2 }
   ],
   "scores": [
     { "worker_name": "rig1", "completed_chunks": 95, "total_keys": "6300000000000" }
@@ -164,6 +164,7 @@ Dashboard data — polled every 3 seconds by `index.html`.
 | `active` | boolean | `true` if last seen within 3 minutes AND holds an assigned chunk in this puzzle (green dot); `false` if within `TIMEOUT_MINUTES` grace period but stale or unassigned (gray dot) |
 | `current_chunk` | number\|null | ID of the currently assigned chunk; null if none |
 | `current_shard` | number\|null | 0-based index of the sector the current chunk belongs to; null if no chunk or pre-migration chunk |
+| `current_chunk_in_shard` | number\|null | 0-based serial number of the current chunk within its sector (chunk creation order); null if no chunk or pre-migration chunk without a sector |
 
 `chunks_vis[].s` and `.e` are fractional positions within the puzzle range (0.0–1.0),
 used by the canvas visualisations.

--- a/public/index.html
+++ b/public/index.html
@@ -950,7 +950,7 @@
                     <td class="td-mono">${w.version || 'unknown'}</td>
                     <td class="td-speed">${formatHashrate(w.hashrate)}</td>
                     <td class="td-chunks">${w.current_chunk ? '#'+w.current_chunk : '—'}</td>
-                    <td class="td-chunks">${w.current_shard != null ? w.current_shard : '—'}</td>
+                    <td class="td-chunks">${w.current_shard != null ? (w.current_chunk_in_shard != null ? `${w.current_shard}/${w.current_chunk_in_shard}` : w.current_shard) : '—'}</td>
                     <td class="td-time">${fmtUtc(w.last_seen)}</td>
                 </tr>`;
                 }).join('');

--- a/public/index.html
+++ b/public/index.html
@@ -329,7 +329,7 @@
                     <pre class="request">{
   "name":     "rig-01",   <span class="comment">// worker id (any unique string)</span>
   "hashrate": 5000000,    <span class="comment">// keys/s, used to size the chunk</span>
-  "version":  "1.2.1"    <span class="comment">// optional; for Active Workers table</span>
+  "version":  "1.2.1"    <span class="comment">// optional; displayed in Visible Workers table</span>
 }</pre>
                 </div>
                 <div class="api-panel">

--- a/server.js
+++ b/server.js
@@ -532,16 +532,21 @@ app.get('/api/v1/stats', (req, res) => {
             SELECT c.id, c.worker_name,
                 CASE WHEN c.sector_id IS NULL THEN NULL
                      ELSE (SELECT COUNT(*) FROM sectors s2 WHERE s2.puzzle_id = c.puzzle_id AND s2.id < c.sector_id)
-                END AS shard_num
+                END AS shard_num,
+                CASE WHEN c.sector_id IS NULL THEN NULL
+                     ELSE (SELECT COUNT(*) FROM chunks c2 WHERE c2.sector_id = c.sector_id AND c2.id < c.id)
+                END AS chunk_in_shard
             FROM chunks c
             WHERE c.status = 'assigned' AND c.puzzle_id = ? AND c.is_test = 0
         `).all(puzzle.id)
         : [];
     const workerChunkMap = {};
     const workerShardMap = {};
+    const workerChunkInShardMap = {};
     for (const c of assignedNow) {
         workerChunkMap[c.worker_name] = c.id;
         workerShardMap[c.worker_name] = c.shard_num;
+        workerChunkInShardMap[c.worker_name] = c.chunk_in_shard;
     }
 
     const workers = visibleWorkers.map(w => ({
@@ -551,6 +556,7 @@ app.get('/api/v1/stats', (req, res) => {
         active: w.active === 1,
         current_chunk: workerChunkMap[w.name] ?? null,
         current_shard: workerShardMap[w.name] ?? null,
+        current_chunk_in_shard: workerChunkInShardMap[w.name] ?? null,
     }));
 
     let chunks_vis = [];

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -312,6 +312,21 @@ describe('GET /api/v1/stats', () => {
         expect(oldChunk.status).toBe('reclaimed');
     });
 
+    test('current_chunk_in_shard is 0 for first chunk and 1 for second chunk in same shard', async () => {
+        seedPuzzle(db);
+        await request(app).post('/api/v1/work').send({ name: 'w1', hashrate: 1000000 });
+        await request(app).post('/api/v1/work').send({ name: 'w2', hashrate: 1000000 });
+
+        const res = await request(app).get('/api/v1/stats').expect(200);
+        const w1 = res.body.workers.find(w => w.name === 'w1');
+        const w2 = res.body.workers.find(w => w.name === 'w2');
+
+        expect(w1.current_shard).toBe(0);
+        expect(w1.current_chunk_in_shard).toBe(0);
+        expect(w2.current_shard).toBe(0);
+        expect(w2.current_chunk_in_shard).toBe(1);
+    });
+
     test('finders entry includes shard, chunk, and chunk_global', async () => {
         seedPuzzle(db);
         const r = await request(app).post('/api/v1/work').send({ name: 'w1', hashrate: 1000000 });


### PR DESCRIPTION
## Summary

- Adds `current_chunk_in_shard` to the `/api/v1/stats` workers[] response — 0-based serial number of the worker's current chunk within its shard (same COUNT pattern used by the finders table)
- Shard column in the Visible Workers table now renders `shard/chunk_in_shard` (e.g. `0/2`); falls back to shard-only for legacy chunks without a `sector_id`
- `docs/api.md` updated with new field and example JSON

## Test plan

- [ ] `npm test` — 53 tests pass (1 new: asserts first worker in shard gets `0`, second gets `1`)
- [ ] Deploy to test server, start two workers — Shard column shows e.g. `0/0` and `0/1`

Closes #37