### PR TITLE
feat: add inactive_workers_count to stats and Active Workers card (#40)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -134,6 +134,7 @@ Dashboard data — polled every 3 seconds by `index.html`.
     "test_chunk": null
   },
   "active_workers_count": 3,
+  "inactive_workers_count": 1,
   "total_hashrate": 24500000,
   "completed_chunks": 187,
   "reclaimed_chunks": 3,

--- a/public/index.html
+++ b/public/index.html
@@ -234,6 +234,7 @@
             <div class="stat-card">
                 <div class="stat-label">Active Workers</div>
                 <div id="active-workers" class="stat-value amber">—</div>
+                <div id="inactive-workers" class="stat-subtext">—</div>
             </div>
             <div class="stat-card">
                 <div class="stat-label">Chunks Done</div>
@@ -895,6 +896,7 @@
                 renderKeyspaceTabs(data.puzzles || []);
                 document.getElementById('total-hashrate').textContent = formatHashrate(data.total_hashrate);
                 document.getElementById('active-workers').textContent = data.active_workers_count;
+                document.getElementById('inactive-workers').textContent = data.puzzle ? ('Inactive: ' + data.inactive_workers_count) : '—';
                 document.getElementById('completed-chunks').textContent = data.completed_chunks.toLocaleString();
                 document.getElementById('reclaimed-chunks').textContent = data.puzzle ? ('Reclaimed: ' + data.reclaimed_chunks.toLocaleString()) : '—';
                 document.getElementById('completed-keys').textContent = formatBigInt(data.total_keys_completed);

--- a/server.js
+++ b/server.js
@@ -603,6 +603,7 @@ app.get('/api/v1/stats', (req, res) => {
             } : null,
         } : null,
         active_workers_count: visibleWorkers.filter(w => w.active).length,
+        inactive_workers_count: visibleWorkers.filter(w => !w.active).length,
         total_hashrate: totalHashrate,
         completed_chunks: completedChunks,
         reclaimed_chunks: reclaimedChunks,

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -272,6 +272,17 @@ describe('GET /api/v1/stats', () => {
         expect(res.body.active_workers_count).toBe(0);
     });
 
+    test('inactive_workers_count: one active and one inactive worker', async () => {
+        seedPuzzle(db);
+        await request(app).post('/api/v1/work').send({ name: 'w1', hashrate: 1000000 });
+        await request(app).post('/api/v1/work').send({ name: 'w2', hashrate: 1000000 });
+        // Age w2 past the active threshold but keep it within TIMEOUT_MINUTES
+        db.prepare(`UPDATE workers SET last_seen = datetime('now', '-${STALE_MINUTES} minutes') WHERE name = 'w2'`).run();
+        const res = await request(app).get('/api/v1/stats').expect(200);
+        expect(res.body.active_workers_count).toBe(1);
+        expect(res.body.inactive_workers_count).toBe(1);
+    });
+
     test('worker removed from table after TIMEOUT_MINUTES', async () => {
         seedPuzzle(db);
         await request(app).post('/api/v1/work').send({ name: 'w1', hashrate: 1000000 });


### PR DESCRIPTION
## Summary

- `inactive_workers_count` added to `/api/v1/stats` response (visible workers where `active === false`, puzzle-scoped)
- Active Workers stat card shows a second line "Inactive: X" in subtext style
- `docs/api.md` updated with new field in example JSON
- 1 new test: one active + one inactive worker → correct counts on both fields

## Test plan

- [x] `npm test` — 54 tests pass
- [x] Deploy to test server, start a worker then kill it — card should show `1` active dropping to `0` / `1` inactive after ~70s

Closes #40