### PR TITLE
fix: formatting in worker progress column

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1217,7 +1217,7 @@ curl -sS "$POOL_SERVER/api/v1/stats?puzzle_id=1"</pre>
                     <div class="progress-bar">
                         <div class="progress-bar-fill" style="width:${clamped}%; background:${color};"></div>
                     </div>
-                    <span class="progress-label" style="color:${color};">${rounded} %</span>
+                    <span class="progress-label" style="color:${color};">${rounded}%</span>
                 </div>
             `;
         }
@@ -1794,7 +1794,6 @@ curl -sS "$POOL_SERVER/api/v1/stats?puzzle_id=1"</pre>
                             }
                         }
 
-                        //const progress = formatWorkerProgress(w, data);
                         const progress = renderWorkerProgress(w, data);
 
                         return `<tr${dim}>


### PR DESCRIPTION
## Summary

- Fixed formatting in the progress column of the Active Workers table (`public/index.html`)

## Test plan

- [ ] Deploy to test server and verify progress column formatting looks correct