### PR TITLE
feat: bigint-native vchunk allocator, GCC 12 warning fixes, and All BTC keyspace support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,13 @@ foreach(_tgt puzzpool_core puzzpool)
     endif()
 endforeach()
 
+# main.cpp pulls in asio system headers via crow which trigger false
+# -Wnull-dereference from inlined third-party code; suppress only for
+# the executable target so puzzpool_core still warns on our own code.
+if(NOT MSVC)
+    target_compile_options(puzzpool PRIVATE -Wno-null-dereference)
+endif()
+
 find_package(Threads REQUIRED)
 target_link_libraries(puzzpool_core PUBLIC Threads::Threads)
 

--- a/src/service_stats.cpp
+++ b/src/service_stats.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <map>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -84,11 +85,16 @@ json PoolService::buildStats(const PuzzleRow& puzzle) {
           )
         ORDER BY w.hashrate DESC
     )SQL");
-    wq.bind(1, "-" + formatDouble(cfg_.activeMinutes) + " minutes");
+    auto mkInterval = [](const std::string& n) {
+        std::ostringstream oss; oss << '-' << n << " minutes"; return oss.str();
+    };
+    const std::string activeParam  = mkInterval(formatDouble(cfg_.activeMinutes));
+    const std::string timeoutParam = mkInterval(std::to_string(cfg_.timeoutMinutes));
+    wq.bind(1, activeParam);
     wq.bind(2, puzzle.id);
-    wq.bind(3, "-" + formatDouble(cfg_.activeMinutes) + " minutes");
+    wq.bind(3, activeParam);
     wq.bind(4, puzzle.id);
-    wq.bind(5, "-" + std::to_string(cfg_.timeoutMinutes) + " minutes");
+    wq.bind(5, timeoutParam);
     wq.bind(6, puzzle.id);
 
     std::map<std::string, json> workerAssignedMap;

--- a/src/work_service.cpp
+++ b/src/work_service.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <sstream>
 #include <string>
 
 namespace puzzpool {
@@ -86,8 +87,8 @@ bool WorkService::heartbeat(const std::string& name, int64_t jobId) {
 int WorkService::reclaimTimedOutChunks() {
     const auto& cfg = db_.cfg();
 
-    const std::string timeoutExpr =
-        std::string("-") + std::to_string(cfg.timeoutMinutes) + " minutes";
+    std::ostringstream _to; _to << '-' << cfg.timeoutMinutes << " minutes";
+    const std::string timeoutExpr = _to.str();
 
     SQLite::Statement q(db_.raw(), R"SQL(
         UPDATE chunks
@@ -110,8 +111,8 @@ bool WorkService::upsertWorkerAndDetectReactivation(
 
     const auto& cfg = db_.cfg();
 
-    const std::string reactivateExpr =
-        std::string("-") + std::to_string(cfg.reactivateMinutes) + " minutes";
+    std::ostringstream _ra; _ra << '-' << cfg.reactivateMinutes << " minutes";
+    const std::string reactivateExpr = _ra.str();
 
     SQLite::Statement prev(
         db_.raw(),


### PR DESCRIPTION
## Summary

- **feat (#79)**: Make the virtual chunk allocator bigint-native — virtual chunk count and cursor now use `cpp_int` + 64-char zero-padded hex TEXT columns in SQLite, eliminating the INT64_MAX chunk-size inflation that produced 2^194-key packages for the All BTC keyspace
- **fix (#79)**: Resolve four remaining int64-era paths flagged in review: admin set-puzzle guard, `handleAdminPuzzles` null output, stats `started`/`completed` accounting for large domains, worker `current_vchunk` fields for large domains
- **fix (#81)**: Eliminate GCC 12 `-Wrestrict` false positives (chained `std::string::operator+` with Boost MP headers) by rewriting as `std::ostringstream`; suppress `-Wnull-dereference` from asio headers inlined via crow only on the `puzzpool` executable target
- Migration scripts added to upgrade existing databases

## Test plan

- [ ] `cmake -S . -B build && cmake --build build --parallel` — zero warnings on GCC 12 and Clang
- [ ] `ctest --test-dir build --output-on-failure` — all tests pass including `[vchunk]` and `[large]` suites
- [ ] `POST /api/v1/admin/set-puzzle` with All BTC keyspace (`start_hex=0x1`, `end_hex=secp256k1 order`) returns 200
- [ ] `GET /api/v1/stats` returns `virtual_chunks.total` as a large decimal string (not 0 or null) for an All BTC puzzle
- [ ] Worker `current_vchunk_run` fields are non-null for assigned workers on a large-domain puzzle
- [ ] Smoke test: `./build/bin/puzzpool & curl -s http://127.0.0.1:8888/api/v1/stats | python3 -m json.tool; kill %1; rm -f pool.db`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)