### PR TITLE
fix: modernise frontend per web standards audit

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,8 @@
             --transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
         }
 
-        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        html { box-sizing: border-box; }
+        *, *::before, *::after { box-sizing: inherit; margin: 0; padding: 0; }
 
         body {
             background-color: var(--bg-primary);
@@ -38,16 +39,20 @@
             background-size: 50px 50px;
             color: var(--text-primary);
             font-family: var(--font-sans);
-            font-size: 14px;
+            font-size: 0.875rem;
             line-height: 1.6;
             min-height: 100vh;
             padding: 2rem;
+            scrollbar-color: var(--border-default) var(--bg-secondary);
+            scrollbar-width: thin;
         }
 
-        ::-webkit-scrollbar { width: 8px; height: 8px; }
-        ::-webkit-scrollbar-track { background: var(--bg-secondary); }
-        ::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 4px; }
-        ::-webkit-scrollbar-thumb:hover { background: var(--border-hover); }
+        @supports not (scrollbar-color: auto) {
+            ::-webkit-scrollbar { width: 8px; height: 8px; }
+            ::-webkit-scrollbar-track { background: var(--bg-secondary); }
+            ::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 4px; }
+            ::-webkit-scrollbar-thumb:hover { background: var(--border-hover); }
+        }
 
         .container { max-width: 1180px; margin: 0 auto; }
 
@@ -353,6 +358,8 @@
             overflow: hidden;
             margin-bottom: 0.9rem;
             transition: border-color var(--transition);
+            content-visibility: auto;
+            contain-intrinsic-block-size: auto 280px;
         }
 
         .api-block:hover { border-color: var(--border-hover); }
@@ -528,14 +535,13 @@
             box-shadow: 0 0 6px var(--accent-cyan);
         }
 
-        .modal-overlay {
-            position: fixed;
-            inset: 0;
+        #activate-modal {
+            padding: 0;
+            border: none;
+            background: transparent;
+        }
+        #activate-modal::backdrop {
             background: rgba(0,0,0,0.75);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            z-index: 1000;
         }
 
         .modal {
@@ -731,6 +737,16 @@
 
         @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
+        @media (prefers-reduced-motion: reduce) {
+            .status-dot,
+            .worker-dot-on { animation: none; }
+        }
+
+        :where(button, input, [tabindex="0"]):focus-visible {
+            outline: 2px solid var(--accent-cyan);
+            outline-offset: 2px;
+        }
+
         @media (max-width: 900px) {
             .api-table-label {
                 width: 120px;
@@ -762,7 +778,7 @@
         <div class="progress-bar-fill" style="width:${o}%;background:${e};"></div>
       </div>
       <span class="progress-label" style="color:${e};">${o}%</span>
-    </div>`}function ct(t){return t==="virtual_random_chunks_v1"?"Virtual random chunks":t==="legacy_random_shards_v1"?"Legacy random shards":t??"Unknown"}function xt(t){if(!t)return"";if(t.alloc_strategy==="virtual_random_chunks_v1"){const r=t.alloc_cursor??"—",n=t.virtual_chunk_count??"—",o=t.virtual_chunk_size_keys?k(t.virtual_chunk_size_keys):"—",e=t.bootstrap_stage??"—";return[`Allocator: <span style="color:var(--accent-cyan)">${ct(t.alloc_strategy)}</span>`,`cursor: <span style="color:var(--accent-amber)">${v(r)}</span>`,`virtual chunks: <span style="color:var(--accent-cyan)">${v(n)}</span>`,`size: <span style="color:var(--accent-cyan)">${o}</span>`,`bootstrap stage: <span style="color:var(--accent-green)">${v(e)}</span>`].join(" · ")}return`Allocator: <span style="color:var(--accent-cyan)">${ct(t.alloc_strategy)}</span>`}function X(t,r){return`<tr><td colspan="${t}" class="td-empty">${r}</td></tr>`}function at(t,r){if(!t||t.length===0)return null;if(r<=0)return t[0];if(r>=1)return t[t.length-1];const n=(t.length-1)*r,o=Math.floor(n),e=Math.ceil(n);if(o===e)return t[o];const s=n-o;return t[o]*(1-s)+t[e]*s}function dt(t,r){if(!t.length)return null;const n=(t.length-1)*r,o=Math.floor(n),e=Math.ceil(n);if(o===e)return t[o];const s=n-o;return t[o]*(1-s)+t[e]*s}const It={completed:"#0f8",FOUND:"#f36",assigned:"#0cf",reclaimed:"#b80",blocked:"#fff"},J={completed:"rgba(0, 255, 136, 0.4)",FOUND:"rgba(255, 51, 102, 1.0)",assigned:"rgba(0, 204, 255, 0.5)",reclaimed:"rgba(255, 187, 0, 0.3)",blocked:"rgba(255, 255, 255, 0.55)"},L=512,U=128,M=256;function $t(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return;t.width=n,t.height=o;const e=t.getContext("2d");if(e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o),r.length===0)return;const s=new Int32Array(n+1),a=new Int32Array(n+1),f=new Int32Array(n+1),u=new Int32Array(n+1),m=new Int32Array(n+1);for(const y of r){const x=Math.max(0,Math.floor(y.s*n)),g=Math.min(n-1,Math.floor(y.e*n)),p=y.st==="completed"?s:y.st==="assigned"?a:y.st==="reclaimed"?f:y.st==="FOUND"?u:m;p[x]++,p[g+1]--}const l=e.createImageData(n,o),d=l.data;let i=0,c=0,h=0,b=0,$=0;for(let y=0;y<n;y++){i+=s[y],c+=a[y],h+=f[y],b+=u[y],$+=m[y];const x=i+c+h+b+$;if(x===0)continue;let g=10,p=10,_=10;if(b>0)g=255,p=51,_=102;else{const w=i/x,H=c/x,K=$/x,nt=h/x;p+=245*w,_+=126*w,p+=194*H,_+=245*H,g+=255*K,p+=255*K,_+=255*K,g+=177*nt,p+=126*nt}const E=Math.min(255,g)|0,S=Math.min(255,p)|0,j=Math.min(255,_)|0;for(let w=0;w<o;w++){const H=w*n+y<<2;d[H]=E,d[H+1]=S,d[H+2]=j,d[H+3]=255}}e.putImageData(l,0,0)}function Y(t,r=0,n=0,o=0){let e=(t|0)^2654435769;return e=Math.imul(e^(r|0),2246822507),e=Math.imul(e^(n|0),3266489909),e=Math.imul(e^(o|0),668265263),e^=e>>>15,e=Math.imul(e,2246822507),e^=e>>>13,e=Math.imul(e,3266489909),e^=e>>>16,e>>>0}function Bt(t,r){const n=Number.isFinite(t.id)?t.id:0,o=Number.isFinite(t.s)?Math.floor(t.s*2147483647):0,e=Number.isFinite(t.e)?Math.floor(t.e*2147483647):0,s=Y(n,o,e,305441741),a=Y(n,e,o,2654435769),f=Y(o,n,e,1831565813);return{index:s%r,sizeJitter:a,offsetJitter:f}}function Et(t,r){const n=new Array(r);for(const o of t){const e=Bt(o,r);let s=n[e.index];s||(s={hits:[],total:0,completed:0,assigned:0,reclaimed:0,FOUND:0,blocked:0,sizeJitter:e.sizeJitter,offsetJitter:e.offsetJitter},n[e.index]=s),s.hits.push(o),s.total++,o.st==="completed"?s.completed++:o.st==="assigned"?s.assigned++:o.st==="reclaimed"?s.reclaimed++:o.st==="FOUND"?s.FOUND++:o.st==="blocked"&&s.blocked++}return n}function St(t){return t?t.blocked>0?"blocked":t.FOUND>0?"FOUND":t.assigned>0?"assigned":t.completed>0?"completed":t.reclaimed>0?"reclaimed":null:null}function ft(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return[];t.width=n,t.height=o;const e=t.getContext("2d"),s=L*U,a=n/L,f=o/U;e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o);const u=Et(r,s);let m=0;for(const l of u)l&&l.total>m&&(m=l.total);m<1&&(m=1),e.globalCompositeOperation="lighter";for(let l=0;l<s;l++){const d=u[l],i=St(d);if(!i||!d)continue;const c=J[i],h=l%L,b=Math.floor(l/L),$=h*a+a/2,y=b*f+f/2,x=Math.log(d.total+1)/Math.log(m+1),g=Math.max(1,Math.min(2.5,n/500)),p=.85+(d.sizeJitter&255)/255*.45,_=Math.min(2.5,g*(.65+x*.9)*p),E=((d.offsetJitter>>>0&255)/255-.5)*a*.22,S=((d.offsetJitter>>>8&255)/255-.5)*f*.22;e.fillStyle=c,e.beginPath(),e.arc($+E,y+S,_,0,Math.PI*2),e.fill(),d.total>=3&&(e.fillStyle=c,e.beginPath(),e.arc($+E,y+S,_*.45,0,Math.PI*2),e.fill())}return e.globalCompositeOperation="source-over",u}function Ht(t,r){let n=0,o=0,e=Math.floor(r);for(let s=1;s<t;s*=2){const a=1&e>>1,f=1&(e^a);if(f===0){a===1&&(n=s-1-n,o=s-1-o);const u=n;n=o,o=u}n+=s*a,o+=s*f,e=Math.floor(e/4)}return[n,o]}function zt(t,r,n){let o=0,e=r,s=n;for(let a=Math.floor(t/2);a>0;a=Math.floor(a/2)){const f=(e&a)>0?1:0,u=(s&a)>0?1:0;if(o+=a*a*(3*f^u),u===0){f===1&&(e=a-1-e,s=a-1-s);const m=e;e=s,s=m}}return o}function mt(t,r){const n=t.offsetWidth;if(n===0)return;t.width=n,t.height=n;const o=t.getContext("2d"),e=M*M,s=n/M;o.fillStyle="#0a0a0a",o.fillRect(0,0,n,n),o.globalCompositeOperation="lighter";const a=["reclaimed","assigned","completed","FOUND","blocked"];for(const f of a){o.fillStyle=J[f];for(const u of r){if(u.st!==f)continue;const m=Math.floor(u.s*e),[l,d]=Ht(M,m);l<0||l>=M||d<0||d>=M||(o.beginPath(),o.arc(l*s+s/2,d*s+s/2,Math.max(1,Math.min(2.5,n/500)),0,Math.PI*2),o.fill())}}o.globalCompositeOperation="source-over"}function q(t){return t.filter(r=>Number.isFinite(r.id)&&Number.isFinite(r.s)&&Number.isFinite(r.e)).slice().sort((r,n)=>r.id-n.id)}function Ct(t){return q(t).slice().sort((r,n)=>r.s-n.s)}function gt(t){const r=Ct(t);if(r.length<2)return[];const n=[];for(let e=1;e<r.length;e++){const s=r[e].s-r[e-1].s;Number.isFinite(s)&&s>=0&&n.push(s)}if(!n.length)return[];const o=n.reduce((e,s)=>e+s,0)/n.length;return o>0?n.map(e=>e/o).filter(e=>Number.isFinite(e)&&e>=0):[]}function Lt(t){const r=gt(t).slice().sort((l,d)=>l-d);if(!r.length)return null;const n=r.length,o=r.reduce((l,d)=>l+d,0)/n,e=dt(r,.5),s=dt(r,.95),a=r[n-1],f=r.reduce((l,d)=>l+(d-o)*(d-o),0)/n,u=Math.sqrt(f),m=o>0?u/o:null;return{n,mean:o,median:e??0,p95:s??0,max:a,cv:m}}function Ft(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return;t.width=n,t.height=o;const e=t.getContext("2d");e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o);const s=q(r);if(!s.length)return;e.strokeStyle="rgba(255,255,255,0.06)",e.lineWidth=1;for(let u=1;u<4;u++){const m=Math.floor(o*u/4)+.5;e.beginPath(),e.moveTo(0,m),e.lineTo(n,m),e.stroke();const l=Math.floor(n*u/4)+.5;e.beginPath(),e.moveTo(l,0),e.lineTo(l,o),e.stroke()}const a=s.length,f=Math.max(1,Math.min(2.5,n/500));for(let u=0;u<a;u++){const m=s[u],l=a>1?u/(a-1)*(n-1):n/2,d=(1-m.s)*(o-1);e.fillStyle=J[m.st]??"rgba(255,255,255,0.4)",e.beginPath(),e.arc(l,d,f,0,Math.PI*2),e.fill()}}function wt(t,r){const n=q(r).slice().sort((i,c)=>i.s-c.s);if(n.length<2){t.innerHTML='Gap metrics: <span style="color:var(--text-muted)">not enough data</span>';return}const o=[];for(let i=1;i<n.length;i++){const c=n[i].s-n[i-1].s;Number.isFinite(c)&&c>=0&&o.push(c)}if(!o.length){t.innerHTML='Gap metrics: <span style="color:var(--text-muted)">no valid gaps</span>';return}o.sort((i,c)=>i-c);const e=o.length,s=o.reduce((i,c)=>i+c,0)/e,a=at(o,.5),f=at(o,.95),u=o[e-1];let m=0;for(const i of o){const c=i-s;m+=c*c}m/=e;const l=s>0?Math.sqrt(m)/s:null,d=s>0?u/s:null;t.innerHTML=`Gap metrics: n <span style="color:var(--accent-cyan)">${v(e)}</span> · mean <span style="color:var(--accent-amber)">${N(s)}</span> · median <span style="color:var(--accent-amber)">${N(a??0)}</span> · p95 <span style="color:var(--accent-green)">${N(f??0)}</span> · max <span style="color:var(--accent-green)">${N(u)}</span> · cv <span style="color:var(--accent-cyan)">${l!=null?N(l):"—"}</span> · max/mean <span style="color:var(--accent-cyan)">${d!=null?N(d):"—"}</span>`}function Nt(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return;t.width=n,t.height=o;const e=t.getContext("2d");e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o);const s=q(r).slice().sort((i,c)=>i.s-c.s);if(s.length<2)return;const a=[];for(let i=1;i<s.length;i++){const c=s[i].s-s[i-1].s;Number.isFinite(c)&&c>=0&&a.push(c)}if(!a.length)return;const f=Math.min(128,Math.max(32,Math.floor(n/8))),u=new Array(f).fill(0);let m=0;for(const i of a)i>m&&(m=i);m>0||(m=1);for(const i of a){let c=Math.floor(i/m*(f-1));c<0&&(c=0),c>=f&&(c=f-1),u[c]++}const l=Math.max(...u,1),d=n/f;e.strokeStyle="rgba(255,255,255,0.06)",e.lineWidth=1;for(let i=1;i<4;i++){const c=Math.floor(o*i/4)+.5;e.beginPath(),e.moveTo(0,c),e.lineTo(n,c),e.stroke()}e.fillStyle="rgba(0,255,255,0.55)";for(let i=0;i<f;i++){const c=u[i]/l*(o-8);e.fillRect(i*d,o-c,Math.max(1,d-1),c)}}function Tt(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return;t.width=n,t.height=o;const e=t.getContext("2d");e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o);const s=gt(r);if(!s.length)return;const a=6,f=Math.min(96,Math.max(36,Math.floor(n/10))),u=new Array(f).fill(0);for(const i of s){const c=Math.min(i,a);let h=Math.floor(c/a*(f-1));h<0&&(h=0),h>=f&&(h=f-1),u[h]++}const m=Math.max(...u,1),l=n/f;e.strokeStyle="rgba(255,255,255,0.06)",e.lineWidth=1;for(let i=1;i<4;i++){const c=Math.floor(o*i/4)+.5;e.beginPath(),e.moveTo(0,c),e.lineTo(n,c),e.stroke()}const d=1/a*n;e.strokeStyle="rgba(255,176,0,0.85)",e.lineWidth=1,e.beginPath(),e.moveTo(d+.5,0),e.lineTo(d+.5,o),e.stroke(),e.fillStyle="rgba(0,255,136,0.60)";for(let i=0;i<f;i++){const c=u[i]/m*(o-8);e.fillRect(i*l,o-c,Math.max(1,l-1),c)}e.fillStyle="rgba(255,255,255,0.55)",e.font="12px JetBrains Mono, monospace",e.fillText("1× mean",Math.min(n-60,d+6),14),e.fillText(`clip ${a}×`,n-70,14)}function At(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return;t.width=n,t.height=o;const e=t.getContext("2d");e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o);const s=q(r);if(!s.length)return;const a=1024,f=Math.min(128,Math.max(32,Math.floor(o/2))),u=n/a,m=o/f;e.strokeStyle="rgba(255,255,255,0.04)",e.lineWidth=1;for(let d=1;d<4;d++){const i=Math.floor(o*d/4)+.5;e.beginPath(),e.moveTo(0,i),e.lineTo(n,i),e.stroke()}const l=s.length;for(let d=0;d<l;d++){const i=s[d],c=Math.floor(i.s*a)%a,h=Math.floor(d/Math.max(1,l)*f);e.fillStyle=J[i.st]??"rgba(255,255,255,0.5)",e.fillRect(c*u,h*m,Math.max(1,u),Math.max(1,m))}}function ht(t,r,n){Ft(t.scatter,n),Nt(t.gap,n),wt(r,n),Tt(t.gapnorm,n),At(t.residue,n)}function Ot(t){return Lt(t)}function Pt(t){const r=t.st==="FOUND"?"🔑 FOUND":t.st==="assigned"?"⚡ In Progress":t.st==="completed"?"✓ Done":t.st==="blocked"?"⊘ Blocked":"↩ Reclaimed",n=t.st==="blocked"?"":` &nbsp;Chunk #${t.id}`,o=t.st==="blocked"?"":` &nbsp;<span style="color:#e0e0e0">${z(t.w)}</span>`;return`<span style="color:${It[t.st]}">${r}</span>${n}${o}`}function Z(t,r,n){if(!n.length){t.style.display="none";return}let e=n.slice(0,15).map(Pt).join("<br>");n.length>15&&(e+=`<br><span style="color:#888;margin-top:5px;display:inline-block;">+ ${n.length-15} more chunks here</span>`),t.innerHTML=e,t.style.display="block";let s=r.clientX+14,a=r.clientY-t.offsetHeight/2;a<10&&(a=10),a+t.offsetHeight>window.innerHeight&&(a=window.innerHeight-t.offsetHeight-10),t.style.left=s+"px",t.style.top=a+"px"}let B=[],A="feistel",O="native",T="native",Q=[],C=null,V=[],I=null,ut=!1;const F=document.getElementById("ks-tooltip"),P=document.getElementById("keyspace-canvas"),D=document.getElementById("heatmap-canvas"),W=document.getElementById("hilbert-canvas"),yt={scatter:document.getElementById("alloc-scatter-canvas"),gap:document.getElementById("alloc-gap-canvas"),gapnorm:document.getElementById("alloc-gapnorm-canvas"),residue:document.getElementById("alloc-residue-canvas")},pt=document.getElementById("alloc-gap-metrics");function tt(){const t=B.filter(r=>r.st!=="blocked");return A==="all"?t:t.filter(r=>(r.g??"legacy")===A)}function R(t,r){return r==="native"?t.filter(n=>n.st!=="blocked"):r==="blocked"?t.filter(n=>n.st==="blocked"):t}function kt(){$t(P,B),Q=ft(D,R(B,O)),ht(yt,pt,tt()),mt(W,R(B,T))}function Dt(t){if(ut||(ut=!0,t!=="TEST"))return;const r=document.querySelector('link[rel="icon"]');r&&(r.href=r.href.replace("%23F7931A","%23ff3366"));const n=document.getElementById("stage-label");n&&(n.style.display="inline")}function Wt(t,r){C=t,document.getElementById("modal-puzzle-name").textContent=r,document.getElementById("modal-token-input").value=sessionStorage.getItem("adminToken")??"",document.getElementById("modal-error").style.display="none",document.getElementById("activate-modal").style.display="flex"}document.getElementById("modal-cancel").addEventListener("click",()=>{document.getElementById("activate-modal").style.display="none",C=null});document.getElementById("modal-confirm").addEventListener("click",async()=>{const t=document.getElementById("modal-token-input").value.trim(),r=document.getElementById("modal-error");if(r.style.display="none",C===null)return;const n=await bt(C,t);n.ok?(t&&sessionStorage.setItem("adminToken",t),document.getElementById("activate-modal").style.display="none",I=C,et(V.map(o=>({...o,active:o.id===C?1:0}))),C=null,G()):(r.textContent=n.error??"Error",r.style.display="block",n.unauthorized&&sessionStorage.removeItem("adminToken"))});function et(t){var i;const r=(t??[]).map(c=>({...c,active:c.active===!0||c.active===1})),n=r.find(c=>c.active)??r[0],o=n?n.id:null;V=r,I===null&&(I=o),I!==null&&!r.find(c=>c.id===I)&&(I=o);const e=document.getElementById("ks-nav"),s=document.getElementById("ks-tab-strip"),a=document.getElementById("ks-toggle-strip"),f=document.querySelector(".header");if(r.length<=1){e.style.display="none",f.classList.remove("has-ks-tabs"),s.innerHTML="",a.innerHTML="";return}e.style.display="block",f.classList.add("has-ks-tabs");const u=`repeat(${r.length}, 1fr)`;s.style.gridTemplateColumns=u,a.style.gridTemplateColumns=u,s.innerHTML=r.map(c=>`<div class="ks-tab${c.id===I?" active":""}" data-id="${c.id}">${z(c.name)}</div>`).join("");const m=r.findIndex(c=>c.id===I),l=I===o,d=((i=r[m])==null?void 0:i.name)??"";a.innerHTML=`<div class="ks-toggle-cell${l?"":" ks-toggle-inactive"}"
+    </div>`}function ct(t){return t==="virtual_random_chunks_v1"?"Virtual random chunks":t==="legacy_random_shards_v1"?"Legacy random shards":t??"Unknown"}function xt(t){if(!t)return"";if(t.alloc_strategy==="virtual_random_chunks_v1"){const r=t.alloc_cursor??"—",n=t.virtual_chunk_count??"—",o=t.virtual_chunk_size_keys?k(t.virtual_chunk_size_keys):"—",e=t.bootstrap_stage??"—";return[`Allocator: <span style="color:var(--accent-cyan)">${ct(t.alloc_strategy)}</span>`,`cursor: <span style="color:var(--accent-amber)">${v(r)}</span>`,`virtual chunks: <span style="color:var(--accent-cyan)">${v(n)}</span>`,`size: <span style="color:var(--accent-cyan)">${o}</span>`,`bootstrap stage: <span style="color:var(--accent-green)">${v(e)}</span>`].join(" · ")}return`Allocator: <span style="color:var(--accent-cyan)">${ct(t.alloc_strategy)}</span>`}function X(t,r){return`<tr><td colspan="${t}" class="td-empty">${r}</td></tr>`}function at(t,r){if(!t||t.length===0)return null;if(r<=0)return t[0];if(r>=1)return t[t.length-1];const n=(t.length-1)*r,o=Math.floor(n),e=Math.ceil(n);if(o===e)return t[o];const s=n-o;return t[o]*(1-s)+t[e]*s}function dt(t,r){if(!t.length)return null;const n=(t.length-1)*r,o=Math.floor(n),e=Math.ceil(n);if(o===e)return t[o];const s=n-o;return t[o]*(1-s)+t[e]*s}const It={completed:"#0f8",FOUND:"#f36",assigned:"#0cf",reclaimed:"#b80",blocked:"#fff"},J={completed:"rgba(0, 255, 136, 0.4)",FOUND:"rgba(255, 51, 102, 1.0)",assigned:"rgba(0, 204, 255, 0.5)",reclaimed:"rgba(255, 187, 0, 0.3)",blocked:"rgba(255, 255, 255, 0.55)"},L=512,U=128,M=256;function $t(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return;t.width=n,t.height=o;const e=t.getContext("2d");if(e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o),r.length===0)return;const s=new Int32Array(n+1),a=new Int32Array(n+1),f=new Int32Array(n+1),u=new Int32Array(n+1),m=new Int32Array(n+1);for(const y of r){const x=Math.max(0,Math.floor(y.s*n)),g=Math.min(n-1,Math.floor(y.e*n)),p=y.st==="completed"?s:y.st==="assigned"?a:y.st==="reclaimed"?f:y.st==="FOUND"?u:m;p[x]++,p[g+1]--}const l=e.createImageData(n,o),d=l.data;let i=0,c=0,h=0,b=0,$=0;for(let y=0;y<n;y++){i+=s[y],c+=a[y],h+=f[y],b+=u[y],$+=m[y];const x=i+c+h+b+$;if(x===0)continue;let g=10,p=10,_=10;if(b>0)g=255,p=51,_=102;else{const w=i/x,H=c/x,K=$/x,nt=h/x;p+=245*w,_+=126*w,p+=194*H,_+=245*H,g+=255*K,p+=255*K,_+=255*K,g+=177*nt,p+=126*nt}const E=Math.min(255,g)|0,S=Math.min(255,p)|0,j=Math.min(255,_)|0;for(let w=0;w<o;w++){const H=w*n+y<<2;d[H]=E,d[H+1]=S,d[H+2]=j,d[H+3]=255}}e.putImageData(l,0,0)}function Y(t,r=0,n=0,o=0){let e=(t|0)^2654435769;return e=Math.imul(e^(r|0),2246822507),e=Math.imul(e^(n|0),3266489909),e=Math.imul(e^(o|0),668265263),e^=e>>>15,e=Math.imul(e,2246822507),e^=e>>>13,e=Math.imul(e,3266489909),e^=e>>>16,e>>>0}function Bt(t,r){const n=Number.isFinite(t.id)?t.id:0,o=Number.isFinite(t.s)?Math.floor(t.s*2147483647):0,e=Number.isFinite(t.e)?Math.floor(t.e*2147483647):0,s=Y(n,o,e,305441741),a=Y(n,e,o,2654435769),f=Y(o,n,e,1831565813);return{index:s%r,sizeJitter:a,offsetJitter:f}}function Et(t,r){const n=new Array(r);for(const o of t){const e=Bt(o,r);let s=n[e.index];s||(s={hits:[],total:0,completed:0,assigned:0,reclaimed:0,FOUND:0,blocked:0,sizeJitter:e.sizeJitter,offsetJitter:e.offsetJitter},n[e.index]=s),s.hits.push(o),s.total++,o.st==="completed"?s.completed++:o.st==="assigned"?s.assigned++:o.st==="reclaimed"?s.reclaimed++:o.st==="FOUND"?s.FOUND++:o.st==="blocked"&&s.blocked++}return n}function St(t){return t?t.blocked>0?"blocked":t.FOUND>0?"FOUND":t.assigned>0?"assigned":t.completed>0?"completed":t.reclaimed>0?"reclaimed":null:null}function ft(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return[];t.width=n,t.height=o;const e=t.getContext("2d"),s=L*U,a=n/L,f=o/U;e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o);const u=Et(r,s);let m=0;for(const l of u)l&&l.total>m&&(m=l.total);m<1&&(m=1),e.globalCompositeOperation="lighter";for(let l=0;l<s;l++){const d=u[l],i=St(d);if(!i||!d)continue;const c=J[i],h=l%L,b=Math.floor(l/L),$=h*a+a/2,y=b*f+f/2,x=Math.log(d.total+1)/Math.log(m+1),g=Math.max(1,Math.min(2.5,n/500)),p=.85+(d.sizeJitter&255)/255*.45,_=Math.min(2.5,g*(.65+x*.9)*p),E=((d.offsetJitter>>>0&255)/255-.5)*a*.22,S=((d.offsetJitter>>>8&255)/255-.5)*f*.22;e.fillStyle=c,e.beginPath(),e.arc($+E,y+S,_,0,Math.PI*2),e.fill(),d.total>=3&&(e.fillStyle=c,e.beginPath(),e.arc($+E,y+S,_*.45,0,Math.PI*2),e.fill())}return e.globalCompositeOperation="source-over",u}function Ht(t,r){let n=0,o=0,e=Math.floor(r);for(let s=1;s<t;s*=2){const a=1&e>>1,f=1&(e^a);if(f===0){a===1&&(n=s-1-n,o=s-1-o);const u=n;n=o,o=u}n+=s*a,o+=s*f,e=Math.floor(e/4)}return[n,o]}function zt(t,r,n){let o=0,e=r,s=n;for(let a=Math.floor(t/2);a>0;a=Math.floor(a/2)){const f=(e&a)>0?1:0,u=(s&a)>0?1:0;if(o+=a*a*(3*f^u),u===0){f===1&&(e=a-1-e,s=a-1-s);const m=e;e=s,s=m}}return o}function mt(t,r){const n=t.offsetWidth;if(n===0)return;t.width=n,t.height=n;const o=t.getContext("2d"),e=M*M,s=n/M;o.fillStyle="#0a0a0a",o.fillRect(0,0,n,n),o.globalCompositeOperation="lighter";const a=["reclaimed","assigned","completed","FOUND","blocked"];for(const f of a){o.fillStyle=J[f];for(const u of r){if(u.st!==f)continue;const m=Math.floor(u.s*e),[l,d]=Ht(M,m);l<0||l>=M||d<0||d>=M||(o.beginPath(),o.arc(l*s+s/2,d*s+s/2,Math.max(1,Math.min(2.5,n/500)),0,Math.PI*2),o.fill())}}o.globalCompositeOperation="source-over"}function q(t){return t.filter(r=>Number.isFinite(r.id)&&Number.isFinite(r.s)&&Number.isFinite(r.e)).slice().sort((r,n)=>r.id-n.id)}function Ct(t){return q(t).slice().sort((r,n)=>r.s-n.s)}function gt(t){const r=Ct(t);if(r.length<2)return[];const n=[];for(let e=1;e<r.length;e++){const s=r[e].s-r[e-1].s;Number.isFinite(s)&&s>=0&&n.push(s)}if(!n.length)return[];const o=n.reduce((e,s)=>e+s,0)/n.length;return o>0?n.map(e=>e/o).filter(e=>Number.isFinite(e)&&e>=0):[]}function Lt(t){const r=gt(t).slice().sort((l,d)=>l-d);if(!r.length)return null;const n=r.length,o=r.reduce((l,d)=>l+d,0)/n,e=dt(r,.5),s=dt(r,.95),a=r[n-1],f=r.reduce((l,d)=>l+(d-o)*(d-o),0)/n,u=Math.sqrt(f),m=o>0?u/o:null;return{n,mean:o,median:e??0,p95:s??0,max:a,cv:m}}function Ft(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return;t.width=n,t.height=o;const e=t.getContext("2d");e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o);const s=q(r);if(!s.length)return;e.strokeStyle="rgba(255,255,255,0.06)",e.lineWidth=1;for(let u=1;u<4;u++){const m=Math.floor(o*u/4)+.5;e.beginPath(),e.moveTo(0,m),e.lineTo(n,m),e.stroke();const l=Math.floor(n*u/4)+.5;e.beginPath(),e.moveTo(l,0),e.lineTo(l,o),e.stroke()}const a=s.length,f=Math.max(1,Math.min(2.5,n/500));for(let u=0;u<a;u++){const m=s[u],l=a>1?u/(a-1)*(n-1):n/2,d=(1-m.s)*(o-1);e.fillStyle=J[m.st]??"rgba(255,255,255,0.4)",e.beginPath(),e.arc(l,d,f,0,Math.PI*2),e.fill()}}function wt(t,r){const n=q(r).slice().sort((i,c)=>i.s-c.s);if(n.length<2){t.innerHTML='Gap metrics: <span style="color:var(--text-muted)">not enough data</span>';return}const o=[];for(let i=1;i<n.length;i++){const c=n[i].s-n[i-1].s;Number.isFinite(c)&&c>=0&&o.push(c)}if(!o.length){t.innerHTML='Gap metrics: <span style="color:var(--text-muted)">no valid gaps</span>';return}o.sort((i,c)=>i-c);const e=o.length,s=o.reduce((i,c)=>i+c,0)/e,a=at(o,.5),f=at(o,.95),u=o[e-1];let m=0;for(const i of o){const c=i-s;m+=c*c}m/=e;const l=s>0?Math.sqrt(m)/s:null,d=s>0?u/s:null;t.innerHTML=`Gap metrics: n <span style="color:var(--accent-cyan)">${v(e)}</span> · mean <span style="color:var(--accent-amber)">${N(s)}</span> · median <span style="color:var(--accent-amber)">${N(a??0)}</span> · p95 <span style="color:var(--accent-green)">${N(f??0)}</span> · max <span style="color:var(--accent-green)">${N(u)}</span> · cv <span style="color:var(--accent-cyan)">${l!=null?N(l):"—"}</span> · max/mean <span style="color:var(--accent-cyan)">${d!=null?N(d):"—"}</span>`}function Nt(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return;t.width=n,t.height=o;const e=t.getContext("2d");e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o);const s=q(r).slice().sort((i,c)=>i.s-c.s);if(s.length<2)return;const a=[];for(let i=1;i<s.length;i++){const c=s[i].s-s[i-1].s;Number.isFinite(c)&&c>=0&&a.push(c)}if(!a.length)return;const f=Math.min(128,Math.max(32,Math.floor(n/8))),u=new Array(f).fill(0);let m=0;for(const i of a)i>m&&(m=i);m>0||(m=1);for(const i of a){let c=Math.floor(i/m*(f-1));c<0&&(c=0),c>=f&&(c=f-1),u[c]++}const l=Math.max(...u,1),d=n/f;e.strokeStyle="rgba(255,255,255,0.06)",e.lineWidth=1;for(let i=1;i<4;i++){const c=Math.floor(o*i/4)+.5;e.beginPath(),e.moveTo(0,c),e.lineTo(n,c),e.stroke()}e.fillStyle="rgba(0,255,255,0.55)";for(let i=0;i<f;i++){const c=u[i]/l*(o-8);e.fillRect(i*d,o-c,Math.max(1,d-1),c)}}function Tt(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return;t.width=n,t.height=o;const e=t.getContext("2d");e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o);const s=gt(r);if(!s.length)return;const a=6,f=Math.min(96,Math.max(36,Math.floor(n/10))),u=new Array(f).fill(0);for(const i of s){const c=Math.min(i,a);let h=Math.floor(c/a*(f-1));h<0&&(h=0),h>=f&&(h=f-1),u[h]++}const m=Math.max(...u,1),l=n/f;e.strokeStyle="rgba(255,255,255,0.06)",e.lineWidth=1;for(let i=1;i<4;i++){const c=Math.floor(o*i/4)+.5;e.beginPath(),e.moveTo(0,c),e.lineTo(n,c),e.stroke()}const d=1/a*n;e.strokeStyle="rgba(255,176,0,0.85)",e.lineWidth=1,e.beginPath(),e.moveTo(d+.5,0),e.lineTo(d+.5,o),e.stroke(),e.fillStyle="rgba(0,255,136,0.60)";for(let i=0;i<f;i++){const c=u[i]/m*(o-8);e.fillRect(i*l,o-c,Math.max(1,l-1),c)}e.fillStyle="rgba(255,255,255,0.55)",e.font="12px JetBrains Mono, monospace",e.fillText("1× mean",Math.min(n-60,d+6),14),e.fillText(`clip ${a}×`,n-70,14)}function At(t,r){const n=t.offsetWidth,o=t.offsetHeight;if(n===0||o===0)return;t.width=n,t.height=o;const e=t.getContext("2d");e.fillStyle="#0a0a0a",e.fillRect(0,0,n,o);const s=q(r);if(!s.length)return;const a=1024,f=Math.min(128,Math.max(32,Math.floor(o/2))),u=n/a,m=o/f;e.strokeStyle="rgba(255,255,255,0.04)",e.lineWidth=1;for(let d=1;d<4;d++){const i=Math.floor(o*d/4)+.5;e.beginPath(),e.moveTo(0,i),e.lineTo(n,i),e.stroke()}const l=s.length;for(let d=0;d<l;d++){const i=s[d],c=Math.floor(i.s*a)%a,h=Math.floor(d/Math.max(1,l)*f);e.fillStyle=J[i.st]??"rgba(255,255,255,0.5)",e.fillRect(c*u,h*m,Math.max(1,u),Math.max(1,m))}}function ht(t,r,n){Ft(t.scatter,n),Nt(t.gap,n),wt(r,n),Tt(t.gapnorm,n),At(t.residue,n)}function Ot(t){return Lt(t)}function Pt(t){const r=t.st==="FOUND"?"🔑 FOUND":t.st==="assigned"?"⚡ In Progress":t.st==="completed"?"✓ Done":t.st==="blocked"?"⊘ Blocked":"↩ Reclaimed",n=t.st==="blocked"?"":` &nbsp;Chunk #${t.id}`,o=t.st==="blocked"?"":` &nbsp;<span style="color:#e0e0e0">${z(t.w)}</span>`;return`<span style="color:${It[t.st]}">${r}</span>${n}${o}`}function Z(t,r,n){if(!n.length){t.style.display="none";return}let e=n.slice(0,15).map(Pt).join("<br>");n.length>15&&(e+=`<br><span style="color:#888;margin-top:5px;display:inline-block;">+ ${n.length-15} more chunks here</span>`),t.innerHTML=e,t.style.display="block";let s=r.clientX+14,a=r.clientY-t.offsetHeight/2;a<10&&(a=10),a+t.offsetHeight>window.innerHeight&&(a=window.innerHeight-t.offsetHeight-10),t.style.left=s+"px",t.style.top=a+"px"}let B=[],A="feistel",O="native",T="native",Q=[],C=null,V=[],I=null,ut=!1;const F=document.getElementById("ks-tooltip"),P=document.getElementById("keyspace-canvas"),D=document.getElementById("heatmap-canvas"),W=document.getElementById("hilbert-canvas"),yt={scatter:document.getElementById("alloc-scatter-canvas"),gap:document.getElementById("alloc-gap-canvas"),gapnorm:document.getElementById("alloc-gapnorm-canvas"),residue:document.getElementById("alloc-residue-canvas")},pt=document.getElementById("alloc-gap-metrics");function tt(){const t=B.filter(r=>r.st!=="blocked");return A==="all"?t:t.filter(r=>(r.g??"legacy")===A)}function R(t,r){return r==="native"?t.filter(n=>n.st!=="blocked"):r==="blocked"?t.filter(n=>n.st==="blocked"):t}function kt(){$t(P,B),Q=ft(D,R(B,O)),ht(yt,pt,tt()),mt(W,R(B,T))}function Dt(t){if(ut||(ut=!0,t!=="TEST"))return;const r=document.querySelector('link[rel="icon"]');r&&(r.href=r.href.replace("%23F7931A","%23ff3366"));const n=document.getElementById("stage-label");n&&(n.style.display="inline")}function Wt(t,r){C=t,document.getElementById("modal-puzzle-name").textContent=r,document.getElementById("modal-token-input").value=sessionStorage.getItem("adminToken")??"",document.getElementById("modal-error").style.display="none",document.getElementById("activate-modal").showModal()}document.getElementById("modal-cancel").addEventListener("click",()=>{document.getElementById("activate-modal").close(),C=null});document.getElementById("modal-confirm").addEventListener("click",async()=>{const t=document.getElementById("modal-token-input").value.trim(),r=document.getElementById("modal-error");if(r.style.display="none",C===null)return;const n=await bt(C,t);n.ok?(t&&sessionStorage.setItem("adminToken",t),document.getElementById("activate-modal").close(),I=C,et(V.map(o=>({...o,active:o.id===C?1:0}))),C=null,G()):(r.textContent=n.error??"Error",r.style.display="block",n.unauthorized&&sessionStorage.removeItem("adminToken"))});function et(t){var i;const r=(t??[]).map(c=>({...c,active:c.active===!0||c.active===1})),n=r.find(c=>c.active)??r[0],o=n?n.id:null;V=r,I===null&&(I=o),I!==null&&!r.find(c=>c.id===I)&&(I=o);const e=document.getElementById("ks-nav"),s=document.getElementById("ks-tab-strip"),a=document.getElementById("ks-toggle-strip"),f=document.querySelector(".header");if(r.length<=1){e.style.display="none",f.classList.remove("has-ks-tabs"),s.innerHTML="",a.innerHTML="";return}e.style.display="block",f.classList.add("has-ks-tabs");const u=`repeat(${r.length}, 1fr)`;s.style.gridTemplateColumns=u,a.style.gridTemplateColumns=u,s.innerHTML=r.map(c=>`<div class="ks-tab${c.id===I?" active":""}" data-id="${c.id}">${z(c.name)}</div>`).join("");const m=r.findIndex(c=>c.id===I),l=I===o,d=((i=r[m])==null?void 0:i.name)??"";a.innerHTML=`<div class="ks-toggle-cell${l?"":" ks-toggle-inactive"}"
     style="grid-column:${m+1}" data-id="${I}">
     <label class="ks-toggle">
       <input type="checkbox"${l?" checked":""} disabled>
@@ -793,12 +809,12 @@
       </tr>`).join(""):m.innerHTML=X(6,"No keys found yet")}catch(e){console.error(e)}}P.addEventListener("mousemove",t=>{const r=P.offsetWidth,n=t.clientX-P.getBoundingClientRect().left,o=B.filter(e=>{const s=e.s*r,a=Math.max(1,(e.e-e.s)*r);return n>=s-1&&n<=s+a+1});Z(F,t,o)});P.addEventListener("mouseleave",()=>{F.style.display="none"});D.addEventListener("mousemove",t=>{const r=D.getBoundingClientRect(),n=Math.floor((t.clientX-r.left)/r.width*L),o=Math.floor((t.clientY-r.top)/r.height*U);if(n<0||n>=L||o<0||o>=U){F.style.display="none";return}const e=Q[o*L+n];Z(F,t,(e==null?void 0:e.hits)??[])});D.addEventListener("mouseleave",()=>{F.style.display="none"});W.addEventListener("mousemove",t=>{const r=W.getBoundingClientRect(),n=Math.floor((t.clientX-r.left)/r.width*M),o=Math.floor((t.clientY-r.top)/r.height*M);if(n<0||n>=M||o<0||o>=M)return;const e=zt(M,n,o),s=M*M,a=e/s,f=(e+1)/s;Z(F,t,R(B,T).filter(u=>u.s<=f&&u.e>=a))});W.addEventListener("mouseleave",()=>{F.style.display="none"});new ResizeObserver(()=>{requestAnimationFrame(kt)}).observe(document.querySelector(".container"));requestAnimationFrame(()=>{qt(),Ut(),Gt(),G(),setInterval(()=>{G()},5e3)});</script>
 </head>
 <body>
-    <div class="container">
-        <div class="header">
+    <main class="container">
+        <header class="header">
             <h1>PUZZLE POOL</h1>
             <span id="stage-label" style="display:none;position:absolute;left:50%;transform:translateX(-50%);font-family:var(--font-mono);font-size:0.8rem;font-weight:700;color:var(--accent-red);letter-spacing:0.05em;">/TEST SYSTEM/</span>
             <div class="status-badge"><div class="status-dot"></div>ONLINE</div>
-        </div>
+        </header>
 
         <div id="ks-nav" style="display:none">
             <div id="ks-tab-strip"></div>
@@ -852,19 +868,19 @@
                     <div class="ks-legend-item"><div class="ks-swatch" style="background:#fff"></div>Blocked</div>
                 </div>
             </div>
-            <canvas id="keyspace-canvas"></canvas>
+            <canvas id="keyspace-canvas" role="img" aria-label="1D coverage bar: completed, in-progress, reclaimed, blocked, and found ranges across the keyspace"></canvas>
         </div>
 
         <div class="heatmap-wrap">
             <div class="keyspace-label">Night Sky Heatmap
                 <div class="alloc-filter-group" id="hm-layer-filter">
-                    <button class="alloc-filter-btn" data-layer="all">All</button>
-                    <button class="alloc-filter-btn active" data-layer="native">Native</button>
-                    <button class="alloc-filter-btn" data-layer="blocked">Blocked</button>
+                    <button type="button" class="alloc-filter-btn" data-layer="all">All</button>
+                    <button type="button" class="alloc-filter-btn active" data-layer="native">Native</button>
+                    <button type="button" class="alloc-filter-btn" data-layer="blocked">Blocked</button>
                 </div>
             </div>
             <div class="canvas-2d-box">
-                <canvas id="heatmap-canvas"></canvas>
+                <canvas id="heatmap-canvas" role="img" aria-label="2D night-sky heatmap of chunk distribution across the search space"></canvas>
             </div>
         </div>
 
@@ -872,18 +888,18 @@
 
         <div id="workers-section-title" class="section-title">Visible Workers</div>
         <div class="table-wrap" style="margin-bottom: 2rem;">
-            <table>
+            <table aria-label="Visible Workers">
                 <thead>
                     <tr>
-                        <th></th>
-                        <th>Worker</th>
-                        <th>Version</th>
-                        <th>Speed</th>
-                        <th>Job</th>
-                        <th>Start Chunk</th>
-                        <th>Chunks</th>
-                        <th>Progress</th>
-                        <th>Last Seen</th>
+                        <th scope="col"></th>
+                        <th scope="col">Worker</th>
+                        <th scope="col">Version</th>
+                        <th scope="col">Speed</th>
+                        <th scope="col">Job</th>
+                        <th scope="col">Start Chunk</th>
+                        <th scope="col">Chunks</th>
+                        <th scope="col">Progress</th>
+                        <th scope="col">Last Seen</th>
                     </tr>
                 </thead>
                 <tbody id="worker-list"></tbody>
@@ -892,16 +908,16 @@
 
         <div class="section-title">Scores — All Time</div>
         <div class="table-wrap" style="margin-bottom: 2rem;">
-            <table>
-                <thead><tr><th></th><th>Worker</th><th>Keys Completed</th><th>Jobs</th></tr></thead>
+            <table aria-label="All-time scores">
+                <thead><tr><th scope="col"></th><th scope="col">Worker</th><th scope="col">Keys Completed</th><th scope="col">Jobs</th></tr></thead>
                 <tbody id="score-list"></tbody>
             </table>
         </div>
 
         <div class="section-title">Keys Found</div>
         <div class="table-wrap" style="margin-bottom: 2.5rem;">
-            <table>
-                <thead><tr><th>Worker</th><th>Address</th><th>Virtual Chunk Start</th><th>Virtual Chunk End</th><th>Job ID</th><th>Datetime</th></tr></thead>
+            <table aria-label="Keys Found">
+                <thead><tr><th scope="col">Worker</th><th scope="col">Address</th><th scope="col">Virtual Chunk Start</th><th scope="col">Virtual Chunk End</th><th scope="col">Job ID</th><th scope="col">Datetime</th></tr></thead>
                 <tbody id="finder-list"></tbody>
             </table>
         </div>
@@ -911,10 +927,10 @@
             <div class="alloc-filter-row">
                 <div class="alloc-filter-label">Generation</div>
                 <div class="alloc-filter-group" id="alloc-generation-filter">
-                    <button class="alloc-filter-btn" data-gen="all">All</button>
-                    <button class="alloc-filter-btn" data-gen="legacy">Legacy</button>
-                    <button class="alloc-filter-btn" data-gen="affine">Affine</button>
-                    <button class="alloc-filter-btn active" data-gen="feistel">Feistel</button>
+                    <button type="button" class="alloc-filter-btn" data-gen="all">All</button>
+                    <button type="button" class="alloc-filter-btn" data-gen="legacy">Legacy</button>
+                    <button type="button" class="alloc-filter-btn" data-gen="affine">Affine</button>
+                    <button type="button" class="alloc-filter-btn active" data-gen="feistel">Feistel</button>
                 </div>
             </div>
 
@@ -925,14 +941,14 @@
                 <div>
                     <div class="section-title" style="margin-bottom:0.5rem;">Assignment Order → Virtual Chunk Start</div>
                     <div class="canvas-2d-box">
-                        <canvas id="alloc-scatter-canvas"></canvas>
+                        <canvas id="alloc-scatter-canvas" role="img" aria-label="Scatter plot: assignment order vs virtual chunk start position"></canvas>
                     </div>
                 </div>
 
                 <div>
                     <div class="section-title" style="margin-bottom:0.5rem;">Sorted Gap Histogram</div>
                     <div class="canvas-2d-box">
-                        <canvas id="alloc-gap-canvas"></canvas>
+                        <canvas id="alloc-gap-canvas" role="img" aria-label="Sorted gap histogram between consecutive virtual chunk starts"></canvas>
                     </div>
                     <div id="alloc-gap-metrics" class="stat-subtext" style="margin-top:0.5rem;"></div>
                 </div>
@@ -940,14 +956,14 @@
                 <div>
                     <div class="section-title" style="margin-bottom:0.5rem;">Normalized Nearest-Neighbor Gap Histogram</div>
                     <div class="canvas-2d-box">
-                        <canvas id="alloc-gapnorm-canvas"></canvas>
+                        <canvas id="alloc-gapnorm-canvas" role="img" aria-label="Normalized nearest-neighbor gap histogram showing distribution uniformity"></canvas>
                     </div>
                 </div>    
 
                 <div>
                     <div class="section-title" style="margin-bottom:0.5rem;">Low Bits Residue Map</div>
                     <div class="canvas-2d-box">
-                        <canvas id="alloc-residue-canvas"></canvas>
+                        <canvas id="alloc-residue-canvas" role="img" aria-label="Low bits residue map showing allocation pattern in low-order key bits"></canvas>
                     </div>
                 </div>
             </div>
@@ -956,13 +972,13 @@
         <div class="hilbert-wrap">
             <div class="keyspace-label">Hilbert Curve Mapping (Full Scale)
                 <div class="alloc-filter-group" id="hil-layer-filter">
-                    <button class="alloc-filter-btn" data-layer="all">All</button>
-                    <button class="alloc-filter-btn active" data-layer="native">Native</button>
-                    <button class="alloc-filter-btn" data-layer="blocked">Blocked</button>
+                    <button type="button" class="alloc-filter-btn" data-layer="all">All</button>
+                    <button type="button" class="alloc-filter-btn active" data-layer="native">Native</button>
+                    <button type="button" class="alloc-filter-btn" data-layer="blocked">Blocked</button>
                 </div>
             </div>
             <div class="canvas-2d-box">
-                <canvas id="hilbert-canvas"></canvas>
+                <canvas id="hilbert-canvas" role="img" aria-label="Hilbert curve mapping of chunk status across the full keyspace"></canvas>
             </div>
         </div>
 
@@ -1336,11 +1352,11 @@ curl -sS "$POOL_SERVER/api/v1/stats?puzzle_id=1"</pre>
                 </tbody>
             </table>
         </div>
-    </div>
+    </main>
 
-    <div class="modal-overlay" id="activate-modal" style="display:none">
+    <dialog id="activate-modal" aria-labelledby="modal-title">
         <div class="modal">
-            <div class="modal-title">Switch keyspace?</div>
+            <div class="modal-title" id="modal-title">Switch keyspace?</div>
             <div class="modal-body">
                 Activate <strong id="modal-puzzle-name"></strong>?<br>
                 Workers will receive chunks from this keyspace on their next request.
@@ -1352,11 +1368,11 @@ curl -sS "$POOL_SERVER/api/v1/stats?puzzle_id=1"</pre>
             </div>
             <div class="modal-error" id="modal-error"></div>
             <div class="modal-buttons">
-                <button class="modal-btn modal-btn-cancel" id="modal-cancel">Cancel</button>
-                <button class="modal-btn modal-btn-confirm" id="modal-confirm">Activate</button>
+                <button type="button" class="modal-btn modal-btn-cancel" id="modal-cancel">Cancel</button>
+                <button type="button" class="modal-btn modal-btn-confirm" id="modal-confirm">Activate</button>
             </div>
         </div>
-    </div>
+    </dialog>
 
 
 </body>


### PR DESCRIPTION
Implements all findings from the modern-web-guidance frontend audit.

## Changes

### CSS
- `font-size: 14px` → `0.875rem` on body (respects browser font preferences)
- Standard `scrollbar-color` / `scrollbar-width` added; webkit rules guarded with `@supports not (scrollbar-color: auto)`
- `#activate-modal` + `::backdrop` replaces the old `.modal-overlay` rules
- `@media (prefers-reduced-motion: reduce)` disables `pulse` animation
- `:where(button, input, [tabindex="0"]):focus-visible` — 2 px cyan focus ring
- `content-visibility: auto` + `contain-intrinsic-block-size` on `.api-block`
- Global reset: `html { box-sizing: border-box }` + children inherit

### HTML
- `<div class="container">` → `<main class="container">` semantic landmark
- `<div class="header">` → `<header class="header">` semantic landmark
- All three data tables get `aria-label` + `scope="col"` on every `<th>`
- All six canvas elements get `role="img"` + descriptive `aria-label`
- `type="button"` on all 11 filter buttons and both modal buttons
- `<div class="modal-overlay">` → `<dialog id="activate-modal" aria-labelledby="modal-title">`; `id="modal-title"` on title element

### JavaScript
- `style.display="flex"` → `.showModal()`; two `style.display="none"` → `.close()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)