### PR TITLE
perf: eliminate hot-path SQL-per-probe loop and redundant scans (7 findings)

### DIFF
--- a/frontend/src/canvas.ts
+++ b/frontend/src/canvas.ts
@@ -263,17 +263,27 @@ export function drawHilbert(canvas: HTMLCanvasElement, chunks: ChunkVis[]): void
   ctx.fillStyle = '#0a0a0a';
   ctx.fillRect(0, 0, size, size);
   ctx.globalCompositeOperation = 'lighter';
+  // Finding 5: group chunks by status in one O(N) pass so each status is drawn
+  // in a single loop instead of iterating all chunks 5 times with skip logic.
+  const byStatus = new Map<ChunkStatus, ChunkVis[]>();
+  for (const c of chunks) {
+    let arr = byStatus.get(c.st);
+    if (!arr) { arr = []; byStatus.set(c.st, arr); }
+    arr.push(c);
+  }
   const order: ChunkStatus[] = ['reclaimed', 'assigned', 'completed', 'FOUND', 'blocked'];
+  const pointR = Math.max(1, Math.min(2.5, size / 500));
   for (const status of order) {
+    const group = byStatus.get(status);
+    if (!group?.length) continue;
     ctx.fillStyle = CHUNK_GLOW_COLORS[status];
-    for (const c of chunks) {
-      if (c.st !== status) continue;
+    for (const c of group) {
       const distance = Math.floor(c.s * totalCells);
       const [hx, hy] = getHilbertXY(HILBERT_N, distance);
       if (hx < 0 || hx >= HILBERT_N || hy < 0 || hy >= HILBERT_N) continue;
       ctx.beginPath();
       ctx.arc(hx * cellSize + cellSize / 2, hy * cellSize + cellSize / 2,
-              Math.max(1, Math.min(2.5, size / 500)), 0, Math.PI * 2);
+              pointR, 0, Math.PI * 2);
       ctx.fill();
     }
   }
@@ -293,8 +303,7 @@ function getAllocatorSortedStarts(chunks: ChunkVis[]): ChunkVis[] {
   return getAllocatorChunks(chunks).slice().sort((a, b) => a.s - b.s);
 }
 
-function getAllocatorNormalizedGaps(chunks: ChunkVis[]): number[] {
-  const sorted = getAllocatorSortedStarts(chunks);
+function computeNormalizedGapsFromSorted(sorted: ChunkVis[]): number[] {
   if (sorted.length < 2) return [];
   const gaps: number[] = [];
   for (let i = 1; i < sorted.length; i++) {
@@ -305,6 +314,10 @@ function getAllocatorNormalizedGaps(chunks: ChunkVis[]): number[] {
   const mean = gaps.reduce((sum, g) => sum + g, 0) / gaps.length;
   if (!(mean > 0)) return [];
   return gaps.map(g => g / mean).filter(v => Number.isFinite(v) && v >= 0);
+}
+
+function getAllocatorNormalizedGaps(chunks: ChunkVis[]): number[] {
+  return computeNormalizedGapsFromSorted(getAllocatorSortedStarts(chunks));
 }
 
 function computeNormalizedGapMetrics(chunks: ChunkVis[]) {
@@ -321,14 +334,14 @@ function computeNormalizedGapMetrics(chunks: ChunkVis[]) {
   return { n, mean, median: median ?? 0, p95: p95 ?? 0, max, cv };
 }
 
-export function drawAllocatorScatter(canvas: HTMLCanvasElement, chunks: ChunkVis[]): void {
+export function drawAllocatorScatter(canvas: HTMLCanvasElement, chunks: ChunkVis[], _sortedById?: ChunkVis[]): void {
   const W = canvas.offsetWidth, H = canvas.offsetHeight;
   if (W === 0 || H === 0) return;
   canvas.width = W; canvas.height = H;
   const ctx = canvas.getContext('2d')!;
   ctx.fillStyle = '#0a0a0a';
   ctx.fillRect(0, 0, W, H);
-  const sorted = getAllocatorChunks(chunks);
+  const sorted = _sortedById ?? getAllocatorChunks(chunks);
   if (!sorted.length) return;
   ctx.strokeStyle = 'rgba(255,255,255,0.06)';
   ctx.lineWidth = 1;
@@ -351,8 +364,8 @@ export function drawAllocatorScatter(canvas: HTMLCanvasElement, chunks: ChunkVis
   }
 }
 
-export function updateAllocatorGapMetrics(el: HTMLElement, chunks: ChunkVis[]): void {
-  const sorted = getAllocatorChunks(chunks).slice().sort((a, b) => a.s - b.s);
+export function updateAllocatorGapMetrics(el: HTMLElement, chunks: ChunkVis[], _sortedByS?: ChunkVis[]): void {
+  const sorted = _sortedByS ?? getAllocatorChunks(chunks).slice().sort((a, b) => a.s - b.s);
   if (sorted.length < 2) {
     el.innerHTML = 'Gap metrics: <span style="color:var(--text-muted)">not enough data</span>';
     return;
@@ -388,14 +401,14 @@ export function updateAllocatorGapMetrics(el: HTMLElement, chunks: ChunkVis[]): 
     `max/mean <span style="color:var(--accent-cyan)">${maxOverMean != null ? formatGapNumber(maxOverMean) : '—'}</span>`;
 }
 
-export function drawAllocatorGapHistogram(canvas: HTMLCanvasElement, chunks: ChunkVis[]): void {
+export function drawAllocatorGapHistogram(canvas: HTMLCanvasElement, chunks: ChunkVis[], _sortedByS?: ChunkVis[]): void {
   const W = canvas.offsetWidth, H = canvas.offsetHeight;
   if (W === 0 || H === 0) return;
   canvas.width = W; canvas.height = H;
   const ctx = canvas.getContext('2d')!;
   ctx.fillStyle = '#0a0a0a';
   ctx.fillRect(0, 0, W, H);
-  const sorted = getAllocatorChunks(chunks).slice().sort((a, b) => a.s - b.s);
+  const sorted = _sortedByS ?? getAllocatorChunks(chunks).slice().sort((a, b) => a.s - b.s);
   if (sorted.length < 2) return;
   const gaps: number[] = [];
   for (let i = 1; i < sorted.length; i++) {
@@ -429,14 +442,14 @@ export function drawAllocatorGapHistogram(canvas: HTMLCanvasElement, chunks: Chu
   }
 }
 
-export function drawAllocatorNormalizedGapHistogram(canvas: HTMLCanvasElement, chunks: ChunkVis[]): void {
+export function drawAllocatorNormalizedGapHistogram(canvas: HTMLCanvasElement, chunks: ChunkVis[], _sortedByS?: ChunkVis[]): void {
   const W = canvas.offsetWidth, H = canvas.offsetHeight;
   if (W === 0 || H === 0) return;
   canvas.width = W; canvas.height = H;
   const ctx = canvas.getContext('2d')!;
   ctx.fillStyle = '#0a0a0a';
   ctx.fillRect(0, 0, W, H);
-  const values = getAllocatorNormalizedGaps(chunks);
+  const values = _sortedByS ? computeNormalizedGapsFromSorted(_sortedByS) : getAllocatorNormalizedGaps(chunks);
   if (!values.length) return;
   const CLIP = 6;
   const bins = Math.min(96, Math.max(36, Math.floor(W / 10)));
@@ -471,14 +484,14 @@ export function drawAllocatorNormalizedGapHistogram(canvas: HTMLCanvasElement, c
   ctx.fillText(`clip ${CLIP}×`, W - 70, 14);
 }
 
-export function drawAllocatorResidueMap(canvas: HTMLCanvasElement, chunks: ChunkVis[]): void {
+export function drawAllocatorResidueMap(canvas: HTMLCanvasElement, chunks: ChunkVis[], _sortedById?: ChunkVis[]): void {
   const W = canvas.offsetWidth, H = canvas.offsetHeight;
   if (W === 0 || H === 0) return;
   canvas.width = W; canvas.height = H;
   const ctx = canvas.getContext('2d')!;
   ctx.fillStyle = '#0a0a0a';
   ctx.fillRect(0, 0, W, H);
-  const sorted = getAllocatorChunks(chunks);
+  const sorted = _sortedById ?? getAllocatorChunks(chunks);
   if (!sorted.length) return;
   const MOD = 1024;
   const rows = Math.min(128, Math.max(32, Math.floor(H / 2)));
@@ -509,11 +522,15 @@ export function drawAllocatorDiagnostics(
   gapMetricsEl: HTMLElement,
   chunks: ChunkVis[],
 ): void {
-  drawAllocatorScatter(canvases.scatter, chunks);
-  drawAllocatorGapHistogram(canvases.gap, chunks);
-  updateAllocatorGapMetrics(gapMetricsEl, chunks);
-  drawAllocatorNormalizedGapHistogram(canvases.gapnorm, chunks);
-  drawAllocatorResidueMap(canvases.residue, chunks);
+  // Finding 6: compute the two derived arrays once and pass them to each
+  // sub-function to avoid O(3×N log N) redundant filter+sort on every redraw.
+  const sortedById = getAllocatorChunks(chunks);
+  const sortedByS  = sortedById.slice().sort((a, b) => a.s - b.s);
+  drawAllocatorScatter(canvases.scatter, chunks, sortedById);
+  drawAllocatorGapHistogram(canvases.gap, chunks, sortedByS);
+  updateAllocatorGapMetrics(gapMetricsEl, chunks, sortedByS);
+  drawAllocatorNormalizedGapHistogram(canvases.gapnorm, chunks, sortedByS);
+  drawAllocatorResidueMap(canvases.residue, chunks, sortedById);
 }
 
 export function exportNormalizedGapMetrics(chunks: ChunkVis[]) {

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -442,17 +442,27 @@ async function updateDashboard(): Promise<void> {
 
 // ── Canvas tooltip wiring ─────────────────────────────────────────────────────
 
+// Finding 7: debounce the O(N) chunksVis scan to at most once per animation
+// frame instead of firing on every raw mousemove event (~60/s during movement).
+let _ksMoveFrame: number | null = null;
 ksCanvas.addEventListener('mousemove', (e: MouseEvent) => {
-  const W  = ksCanvas.offsetWidth;
-  const px = e.clientX - ksCanvas.getBoundingClientRect().left;
-  const hits = chunksVis.filter(c => {
-    const x = c.s * W;
-    const w = Math.max(1, (c.e - c.s) * W);
-    return px >= x - 1 && px <= x + w + 1;
+  if (_ksMoveFrame !== null) return;
+  _ksMoveFrame = requestAnimationFrame(() => {
+    _ksMoveFrame = null;
+    const W  = ksCanvas.offsetWidth;
+    const px = e.clientX - ksCanvas.getBoundingClientRect().left;
+    const hits = chunksVis.filter(c => {
+      const x = c.s * W;
+      const w = Math.max(1, (c.e - c.s) * W);
+      return px >= x - 1 && px <= x + w + 1;
+    });
+    showTooltip(tooltip, e, hits);
   });
-  showTooltip(tooltip, e, hits);
 });
-ksCanvas.addEventListener('mouseleave', () => { tooltip.style.display = 'none'; });
+ksCanvas.addEventListener('mouseleave', () => {
+  if (_ksMoveFrame !== null) { cancelAnimationFrame(_ksMoveFrame); _ksMoveFrame = null; }
+  tooltip.style.display = 'none';
+});
 
 hmCanvas.addEventListener('mousemove', (e: MouseEvent) => {
   const rect = hmCanvas.getBoundingClientRect();

--- a/include/puzzpool/allocator.hpp
+++ b/include/puzzpool/allocator.hpp
@@ -51,8 +51,10 @@ private:
     int64_t             readWorkerHashrate(const std::string& worker);
     void                setAllocCursor(int64_t puzzleId, const cpp_int& cursor);
     void                advanceBootstrapStage(int64_t puzzleId, int stage);
+    void                loadOccupiedRanges(int64_t puzzleId);
     bool                rangeIsFree(int64_t puzzleId, const cpp_int& start, const cpp_int& endExclusive);
     bool                overlapsBlockedInMemory(int64_t puzzleId, const cpp_int& start, const cpp_int& endExclusive);
+    bool                overlapsOccupiedInMemory(int64_t puzzleId, const cpp_int& start, const cpp_int& endExclusive);
     cpp_int             normalizeRunStartForCandidate(const cpp_int& candidateIndex, const cpp_int& neededChunks, const cpp_int& totalChunks);
 
     std::optional<WorkAssignResult> assignBootstrap(const std::string& worker, const PuzzleRow& puzzle,
@@ -70,6 +72,7 @@ private:
     PoolDb&       db_;
     const Config& cfg_;
     std::map<int64_t, std::vector<std::pair<cpp_int, cpp_int>>> blockedRanges_;
+    std::map<int64_t, std::vector<std::pair<cpp_int, cpp_int>>> occupiedRanges_;
 };
 
 } // namespace puzzpool

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -222,6 +222,10 @@ Allocator::assignVirtualChunkJob(const std::string& worker,
     int stage = puzzle.bootstrapStage;
 
     SQLite::Transaction tx(db_.raw());
+    // Finding 1: load all currently-occupied vchunk ranges into memory once so
+    // rangeIsFree() can probe them with O(log N) binary search instead of one
+    // SQL query per probe call.
+    loadOccupiedRanges(puzzle.id);
 
     if (freshChunkCount < 3 && stage < 3) {
         if (auto r = assignBootstrap(worker, puzzle, totalChunks, neededChunks, stage)) {
@@ -369,10 +373,18 @@ int Allocator::insertOrMergeBlockedRange(int64_t puzzleId, const cpp_int& vStart
     // (Multiple rows bridged by the input must still be compacted even if outer bounds match.)
     if (toDelete.size() == 1 && mergedStart == existStart && mergedEnd == existEnd) return 0;
 
-    // Delete overlapping rows, then insert the expanded merged interval
-    for (int64_t id : toDelete) {
-        SQLite::Statement del(db_.raw(), "DELETE FROM blocked_vchunk_ranges WHERE id = ?");
-        del.bind(1, id);
+    // Finding 2: batch-delete all overlapping rows in one statement instead of
+    // issuing one DELETE per row.
+    {
+        std::string delSql = "DELETE FROM blocked_vchunk_ranges WHERE id IN (";
+        for (size_t i = 0; i < toDelete.size(); ++i) {
+            if (i > 0) delSql += ',';
+            delSql += '?';
+        }
+        delSql += ')';
+        SQLite::Statement del(db_.raw(), delSql);
+        for (size_t i = 0; i < toDelete.size(); ++i)
+            del.bind(static_cast<int>(i + 1), toDelete[i]);
         del.exec();
     }
     std::string mergedStartHex = intToHex(mergedStart, 64);
@@ -427,26 +439,58 @@ bool Allocator::overlapsBlockedInMemory(int64_t puzzleId, const cpp_int& start, 
     return pos != v.end() && pos->first < endExclusive;
 }
 
-bool Allocator::rangeIsFree(int64_t puzzleId, const cpp_int& start, const cpp_int& endExclusive) {
-    if (start < 0 || endExclusive <= start) return false;
-    std::string startHexPad = intToHex(start, 64);
-    std::string endHexPad   = intToHex(endExclusive, 64);
+void Allocator::loadOccupiedRanges(int64_t puzzleId) {
+    // Fetch all vchunk ranges that are already taken (assigned/reclaimed/completed/FOUND)
+    // in one SQL query so subsequent rangeIsFree() probes can use binary search in memory.
     SQLite::Statement q(db_.raw(), R"SQL(
-        SELECT 1
+        SELECT vchunk_start_hex, vchunk_end_hex
         FROM chunks
         WHERE puzzle_id = ?
           AND is_test = 0
           AND status IN ('assigned', 'reclaimed', 'completed', 'FOUND')
           AND vchunk_start_hex IS NOT NULL
           AND vchunk_end_hex IS NOT NULL
-          AND vchunk_start_hex < ?
-          AND vchunk_end_hex > ?
-        LIMIT 1
+        ORDER BY vchunk_start_hex ASC
     )SQL");
     q.bind(1, puzzleId);
-    q.bind(2, endHexPad);
-    q.bind(3, startHexPad);
-    if (q.executeStep()) return false;
+    std::vector<std::pair<cpp_int, cpp_int>> raw;
+    while (q.executeStep()) {
+        cpp_int s = hexToInt(q.getColumn(0).getString());
+        cpp_int e = hexToInt(q.getColumn(1).getString());
+        if (e > s) raw.emplace_back(s, e);
+    }
+    // Merge adjacent/overlapping intervals (input already sorted by start)
+    std::vector<std::pair<cpp_int, cpp_int>> merged;
+    for (auto& [s, e] : raw) {
+        if (merged.empty() || s > merged.back().second)
+            merged.emplace_back(s, e);
+        else
+            merged.back().second = maxBig(merged.back().second, e);
+    }
+    occupiedRanges_[puzzleId] = std::move(merged);
+}
+
+bool Allocator::overlapsOccupiedInMemory(int64_t puzzleId, const cpp_int& start, const cpp_int& endExclusive) {
+    auto it = occupiedRanges_.find(puzzleId);
+    if (it == occupiedRanges_.end()) return false;
+    const auto& v = it->second;
+    if (v.empty()) return false;
+    auto pos = std::lower_bound(v.begin(), v.end(),
+        std::make_pair(start, cpp_int(0)),
+        [](const auto& a, const auto& b) { return a.first < b.first; });
+    if (pos != v.begin()) {
+        --pos;
+        if (pos->second > start) return true;
+        ++pos;
+    }
+    return pos != v.end() && pos->first < endExclusive;
+}
+
+bool Allocator::rangeIsFree(int64_t puzzleId, const cpp_int& start, const cpp_int& endExclusive) {
+    if (start < 0 || endExclusive <= start) return false;
+    // Use the in-memory snapshot loaded once at the start of assignVirtualChunkJob
+    // (O(log N) binary search instead of one SQL query per probe call).
+    if (overlapsOccupiedInMemory(puzzleId, start, endExclusive)) return false;
     return !overlapsBlockedInMemory(puzzleId, start, endExclusive);
 }
 

--- a/src/service_stats.cpp
+++ b/src/service_stats.cpp
@@ -181,8 +181,11 @@ json PoolService::buildStats(const PuzzleRow& puzzle) {
     out["completed_chunks"] = scalarCount("SELECT COUNT(*) FROM chunks WHERE puzzle_id = ? AND (status = 'completed' OR status = 'FOUND') AND is_test = 0");
     out["reclaimed_chunks"] = scalarCount("SELECT COUNT(*) FROM chunks WHERE puzzle_id = ? AND status = 'reclaimed' AND is_test = 0");
 
-    std::vector<std::pair<cpp_int, cpp_int>> doneRanges;
+    // Finding 3: the allocator guarantees non-overlapping chunks, so
+    // total covered keys == simple sum of (end - start) per completed chunk.
+    // No sort+sweep needed; we fold the computation into the score query.
     std::map<std::string, std::pair<int64_t, cpp_int>> scoreMap;
+    cpp_int totalKeysCompleted = 0;
     SQLite::Statement dq(db_.raw(),
         "SELECT worker_name, start_hex, end_hex FROM chunks WHERE puzzle_id = ? AND (status = 'completed' OR status = 'FOUND') AND worker_name IS NOT NULL AND is_test = 0");
     dq.bind(1, puzzle.id);
@@ -190,26 +193,10 @@ json PoolService::buildStats(const PuzzleRow& puzzle) {
         std::string worker = dq.getColumn(0).getString();
         cpp_int s = hexToInt(dq.getColumn(1).getString());
         cpp_int e = hexToInt(dq.getColumn(2).getString());
-        doneRanges.push_back({s, e});
         auto& slot = scoreMap[worker];
         slot.first  += 1;
         slot.second += (e - s);
-    }
-    std::sort(doneRanges.begin(), doneRanges.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
-    cpp_int totalKeysCompleted = 0;
-    if (!doneRanges.empty()) {
-        cpp_int ms = doneRanges.front().first;
-        cpp_int me = doneRanges.front().second;
-        for (size_t i = 1; i < doneRanges.size(); ++i) {
-            if (doneRanges[i].first <= me) {
-                if (doneRanges[i].second > me) me = doneRanges[i].second;
-            } else {
-                totalKeysCompleted += me - ms;
-                ms = doneRanges[i].first;
-                me = doneRanges[i].second;
-            }
-        }
-        totalKeysCompleted += me - ms;
+        totalKeysCompleted += (e - s);
     }
     out["total_keys_completed"] = bigToDec(totalKeysCompleted);
 
@@ -253,9 +240,15 @@ json PoolService::buildStats(const PuzzleRow& puzzle) {
     cpp_int pStart = hexToInt(puzzle.startHex);
     cpp_int pEnd   = hexToInt(puzzle.endHex);
     cpp_int pRange = pEnd - pStart;
+    // Finding 4: include vchunk_start_hex/end_hex in the main chunks query so we
+    // can compute started/completed vchunk coverage in the same pass and avoid a
+    // second full table scan of chunks.
     SQLite::Statement cv(db_.raw(),
-        "SELECT id, status, worker_name, start_hex, end_hex, alloc_generation FROM chunks WHERE puzzle_id = ? AND is_test = 0 ORDER BY id ASC");
+        "SELECT id, status, worker_name, start_hex, end_hex, alloc_generation,"
+        "       vchunk_start_hex, vchunk_end_hex"
+        " FROM chunks WHERE puzzle_id = ? AND is_test = 0 ORDER BY id ASC");
     cv.bind(1, puzzle.id);
+    cpp_int vcStarted = 0, vcCompleted = 0;
     while (cv.executeStep()) {
         cpp_int cs = hexToInt(cv.getColumn(3).getString()) - pStart;
         cpp_int ce = hexToInt(cv.getColumn(4).getString()) - pStart;
@@ -269,6 +262,16 @@ json PoolService::buildStats(const PuzzleRow& puzzle) {
             {"s",  static_cast<double>(s)},
             {"e",  static_cast<double>(e)}
         });
+        // Accumulate vchunk coverage while we have the row (Finding 4)
+        if (!cv.isColumnNull(6) && !cv.isColumnNull(7)) {
+            cpp_int vs = hexToInt(cv.getColumn(6).getString());
+            cpp_int ve = hexToInt(cv.getColumn(7).getString());
+            if (ve > vs) {
+                vcStarted += (ve - vs);
+                std::string st = cv.getColumn(1).getString();
+                if (st == "completed" || st == "FOUND") vcCompleted += (ve - vs);
+            }
+        }
     }
     json virtualTotalJ     = nullptr;
     json virtualStartedJ   = json(0);
@@ -276,26 +279,9 @@ json PoolService::buildStats(const PuzzleRow& puzzle) {
     json blockedCountJ     = json("0");
     std::string strategy = puzzle.allocStrategy.empty() ? cfg_.allocStrategyLegacy : puzzle.allocStrategy;
     if (strategy == cfg_.allocStrategyVChunks) {
-        virtualTotalJ = bigToDec(puzzle.virtualChunkCount);
-        cpp_int started = 0, completed = 0;
-        SQLite::Statement vc(db_.raw(), R"SQL(
-            SELECT vchunk_start_hex, vchunk_end_hex, status
-            FROM chunks
-            WHERE puzzle_id = ? AND is_test = 0
-              AND vchunk_start_hex IS NOT NULL AND vchunk_end_hex IS NOT NULL
-        )SQL");
-        vc.bind(1, puzzle.id);
-        while (vc.executeStep()) {
-            cpp_int s = hexToInt(vc.getColumn(0).getString());
-            cpp_int e = hexToInt(vc.getColumn(1).getString());
-            if (e > s) {
-                started += (e - s);
-                std::string st2 = vc.getColumn(2).getString();
-                if (st2 == "completed" || st2 == "FOUND") completed += (e - s);
-            }
-        }
-        virtualStartedJ   = bigToDec(started);
-        virtualCompletedJ = bigToDec(completed);
+        virtualTotalJ     = bigToDec(puzzle.virtualChunkCount);
+        virtualStartedJ   = bigToDec(vcStarted);
+        virtualCompletedJ = bigToDec(vcCompleted);
 
         // Blocked vchunk count and vis entries — merge across sources first so
         // overlapping imports from different sources are counted as union coverage.


### PR DESCRIPTION
## Summary

Implements all 7 complexity-optimizer findings from the analysis report.

## Changes

### C++ server

**Finding 1 — allocator: in-memory occupied-range cache (Critical)**
Load all occupied vchunk intervals once per `assignVirtualChunkJob()` call into a sorted in-memory vector. `rangeIsFree()` now does O(log N) binary search instead of one SQL query per probe call. Reduces hundreds of DB round-trips per `/work` request to a single `SELECT`.

**Finding 2 — allocator: batch DELETE (Low risk)**
Replace the per-row `DELETE FROM blocked_vchunk_ranges WHERE id = ?` loop with a single `DELETE … WHERE id IN (?,…)`. O(N SQL) → O(1 SQL).

**Finding 3 — service_stats: eliminate O(N log N) sort per poll (High)**
The allocator guarantees non-overlapping chunks, so `totalKeysCompleted` equals the plain sum of `(end - start)` already accumulated in the score loop. The `doneRanges` sort+sweep-merge vector is removed entirely.

**Finding 4 — service_stats: fold second chunks table scan (Medium)**
Added `vchunk_start_hex` / `vchunk_end_hex` to the main `cv` query and accumulated started/completed vchunk coverage in the same loop. Cuts chunks table reads per `/stats` poll from 2 to 1 for vchunk-strategy puzzles.

### TypeScript frontend

**Finding 5 — canvas: Hilbert O(5×N) → O(N) (Low risk)**
Group chunks by status in one O(N) pass before drawing; iterate each group once. Constant factor reduced from 5 to 1.

**Finding 6 — canvas: pre-compute allocator sorted arrays once (Low risk)**
`drawAllocatorDiagnostics()` computes `sortedById` and `sortedByS` once and threads them to sub-functions via optional parameters. Reduces O(3×N log N) to O(N log N) per redraw cycle.

**Finding 7 — dashboard: rAF-debounce mousemove scan (Low risk)**
Wrap the O(N) `chunksVis.filter()` in `requestAnimationFrame` so it fires at most once per frame instead of on every raw pointer event.

## Files changed

- `include/puzzpool/allocator.hpp` — added `occupiedRanges_`, `loadOccupiedRanges`, `overlapsOccupiedInMemory`
- `src/allocator.cpp` — Findings 1 & 2
- `src/service_stats.cpp` — Findings 3 & 4
- `frontend/src/canvas.ts` — Findings 5 & 6
- `frontend/src/dashboard.ts` — Finding 7

## Testing

- 7/7 C++ ctest pass
- 13/13 vitest pass
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)