### PR TITLE
feat: add minimumReleaseAge supply-chain guard for Node.js builds (closes #96)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,12 @@ BLOCKEXPLORER_URL=https://mempool.space/address/
 # are recomputed from local findings on the same schedule.
 BLOCKEXPLORER_POLL_SEC=600
 
+# Supply-chain guard: minimum age (in minutes) a Node.js release must have before
+# it is used during the frontend build step (scripts/check-node-version-age.sh).
+# Default 1440 = 24 hours. Set to 0 to disable (not recommended in production).
+# This variable is read at build time only; it has no effect at server runtime.
+MINIMUM_NODE_RELEASE_AGE=1440
+
 # Keyspace definitions — any number of KEYSPACE_<NAME>=<start_hex>:<end_hex> entries.
 # NAME (underscores replaced with spaces) becomes the puzzle name in the dashboard.
 # On startup, missing puzzles are seeded automatically (inactive by default).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,14 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
+      - name: Check Node.js release age (supply-chain guard)
+        run: bash scripts/check-node-version-age.sh
+        env:
+          MINIMUM_NODE_RELEASE_AGE: 1440
+
+      - name: Run Node.js release-age check unit tests
+        run: bash tests/test_check_node_version_age.sh
+
       - name: Install frontend dependencies
         run: npm ci
         working-directory: frontend

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ cp .env.example .env
 | `PERMUTATION_MODE` | `feistel` | Virtual chunk permutation algorithm: `feistel` (cycle-walking Feistel cipher) or `affine` (linear congruential). Recorded per-chunk as `alloc_generation`. |
 | `KEYSPACE_<NAME>` | *(unset)* | Seed a keyspace on startup: `KEYSPACE_ALL_BTC=<start_hex>:<end_hex>`. Underscores in the variable name become spaces in the puzzle name. Multiple variables are supported. |
 | `PUZZLE_<NAME>_TARGET` | *(unset)* | Optional solved-state target. For address-backed puzzles use a Bitcoin address, for `ALL BTC` use the distinct found-key threshold. Example: `PUZZLE_71_TARGET=1PWo3JeB9jrGwfHDNpdGK54CRas7fsVzXU`, `PUZZLE_ALL_BTC_TARGET=5`. |
+| `MINIMUM_NODE_RELEASE_AGE` | `1440` | **Build-time only.** Minimum age in minutes a Node.js release must have before it is used during the frontend build. Enforced by `scripts/check-node-version-age.sh`. Set to `0` to disable (not recommended in production). See [docs/security.md](docs/security.md) for rationale. |
 
 ---
 

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,9 @@ cmake -S . -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release
 echo "[build] build incrementally"
 cmake --build "$BUILD_DIR" -j
 
+echo "[build] check Node.js release age (supply-chain guard)"
+bash "$(dirname "$0")/scripts/check-node-version-age.sh"
+
 echo "[build] install frontend dependencies"
 npm ci --prefix frontend
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -124,6 +124,51 @@ Certbot with auto-renewal.
 
 ---
 
+## Node.js Supply-Chain Protection
+
+A compromised or malicious Node.js release can introduce vulnerabilities at build time.
+To reduce this risk, a minimum release age is enforced before Node.js is used during the
+frontend build step.
+
+### How it works
+
+The script `scripts/check-node-version-age.sh`:
+1. Reads the installed Node.js version (`node --version`).
+2. Fetches the official Node.js release index from `https://nodejs.org/dist/index.json`.
+3. Calculates how many minutes ago the installed version was published.
+4. Rejects the build if the version is younger than `MINIMUM_NODE_RELEASE_AGE` minutes
+   (default **1440 minutes = 24 hours**), logging the release date and how long until the
+   threshold will be met.
+5. Exits non-zero so the build/CI pipeline fails visibly rather than silently proceeding.
+
+This matches the supply-chain mitigation commonly known as the **minimum release age**
+pattern (also used by Renovate's `minimumReleaseAge` setting).
+
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MINIMUM_NODE_RELEASE_AGE` | `1440` | Minimum age in minutes a Node.js release must have before use. Set to `0` to disable (not recommended in production). |
+
+### Recommended values by risk profile
+
+| Environment | Recommended value | Rationale |
+|-------------|------------------|-----------|
+| Production | `1440` (24 h) | Allows time for community vetting before adoption |
+| Staging / QA | `1440` | Mirror production to catch regressions early |
+| Local development | `0` (disabled) | Developers may intentionally use cutting-edge releases |
+| High-security | `10080` (7 days) | Extended hold for maximum vetting time |
+
+### What to do when a build is rejected
+
+If CI or a local build fails because the Node.js version is too new:
+1. Check the log for the release date and the minutes remaining until it passes.
+2. Wait until the threshold is met — the version will be accepted automatically.
+3. To unblock immediately in a non-production context, set `MINIMUM_NODE_RELEASE_AGE=0` in
+   your environment (do **not** use this in production).
+
+---
+
 ## Recommendations for Production
 
 - Keep `ADMIN_TOKEN` set and rotate it periodically

--- a/scripts/check-node-version-age.sh
+++ b/scripts/check-node-version-age.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scripts/check-node-version-age.sh
+#
+# Supply-chain guard: validates that the installed Node.js release is old enough
+# to have been vetted by the community before it is used in a build or deploy.
+#
+# When a new Node.js release is published there is a window where malicious or
+# accidentally broken packages can slip in. Enforcing a minimum age ensures that
+# only releases that have had time to be scrutinised are used.
+#
+# Environment variables:
+#   MINIMUM_NODE_RELEASE_AGE   Minimum age in minutes a Node.js release must
+#                              have before it is considered safe to use.
+#                              Default: 1440 (= 24 hours).
+#                              Set to 0 to disable the check entirely.
+#
+# Exit codes:
+#   0  Version meets the age requirement (or check is disabled).
+#   1  Version is too new, or the release date could not be determined.
+
+set -euo pipefail
+
+MINIMUM_NODE_RELEASE_AGE="${MINIMUM_NODE_RELEASE_AGE:-1440}"
+
+# ── Allow disabling the check ──────────────────────────────────────────────────
+if [[ "$MINIMUM_NODE_RELEASE_AGE" -eq 0 ]]; then
+    echo "[node-age] check disabled (MINIMUM_NODE_RELEASE_AGE=0)"
+    exit 0
+fi
+
+# ── Resolve installed Node.js version ─────────────────────────────────────────
+if ! command -v node &>/dev/null; then
+    echo "[node-age] ERROR: 'node' not found in PATH" >&2
+    exit 1
+fi
+
+NODE_VERSION="$(node --version | sed 's/^v//')"
+echo "[node-age] installed Node.js: v${NODE_VERSION}"
+echo "[node-age] minimum release age: ${MINIMUM_NODE_RELEASE_AGE} minutes"
+
+# ── Fetch the official Node.js release index ───────────────────────────────────
+RELEASE_INDEX_URL="https://nodejs.org/dist/index.json"
+echo "[node-age] fetching release index from ${RELEASE_INDEX_URL} ..."
+
+# Write to a temp file to avoid shell quoting issues with large JSON blobs
+TMPFILE="$(mktemp)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+if ! curl -sSf --max-time 20 "$RELEASE_INDEX_URL" > "$TMPFILE" 2>/dev/null; then
+    echo "[node-age] ERROR: failed to fetch Node.js release index (network error or timeout)" >&2
+    exit 1
+fi
+
+if [[ ! -s "$TMPFILE" ]]; then
+    echo "[node-age] ERROR: Node.js release index returned empty response" >&2
+    exit 1
+fi
+
+# ── Extract release date using Node.js, reading the index from the temp file ──
+NODE_SCRIPT="
+const fs = require('fs');
+const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+const version = 'v' + process.argv[2];
+const entry = data.find(function(e) { return e.version === version; });
+if (!entry) {
+  process.stderr.write('[node-age] ERROR: ' + version + ' not found in Node.js release index\n');
+  process.exit(1);
+}
+process.stdout.write(entry.date);
+"
+
+RELEASE_DATE="$(node -e "$NODE_SCRIPT" "$TMPFILE" "$NODE_VERSION")"
+
+if [[ -z "$RELEASE_DATE" ]]; then
+    echo "[node-age] ERROR: could not determine release date for v${NODE_VERSION}" >&2
+    exit 1
+fi
+
+echo "[node-age] release date: ${RELEASE_DATE}"
+
+# ── Compute age in minutes using Node.js for cross-platform date parsing ───────
+AGE_SCRIPT="
+var released = new Date(process.argv[1]).getTime();
+var now = Date.now();
+var minutes = Math.floor((now - released) / 60000);
+process.stdout.write(String(minutes));
+"
+AGE_MINUTES="$(node -e "$AGE_SCRIPT" "$RELEASE_DATE")"
+
+echo "[node-age] release age: ${AGE_MINUTES} minutes"
+
+# ── Enforce the threshold ─────────────────────────────────────────────────────
+if [[ "$AGE_MINUTES" -lt "$MINIMUM_NODE_RELEASE_AGE" ]]; then
+    REMAINING=$(( MINIMUM_NODE_RELEASE_AGE - AGE_MINUTES ))
+    echo "" >&2
+    echo "[node-age] REJECTED: v${NODE_VERSION} released on ${RELEASE_DATE} is only ${AGE_MINUTES} min old." >&2
+    echo "[node-age]           Minimum required age: ${MINIMUM_NODE_RELEASE_AGE} minutes." >&2
+    echo "[node-age]           This version will pass the check in ${REMAINING} more minutes." >&2
+    echo "[node-age]           To override (not recommended in production), set MINIMUM_NODE_RELEASE_AGE=0." >&2
+    echo "" >&2
+    exit 1
+fi
+
+echo "[node-age] OK: v${NODE_VERSION} is ${AGE_MINUTES} minutes old — meets the minimum age of ${MINIMUM_NODE_RELEASE_AGE} minutes."

--- a/tests/test_check_node_version_age.sh
+++ b/tests/test_check_node_version_age.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# tests/test_check_node_version_age.sh
+#
+# Unit tests for scripts/check-node-version-age.sh.
+# Uses wrapper scripts to mock 'node --version' and 'curl' without making
+# real network calls. All other 'node' invocations pass through to the real binary.
+#
+# Run:   bash tests/test_check_node_version_age.sh
+# Exit:  0 = all tests passed, non-zero = at least one failure.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-node-version-age.sh"
+
+PASS=0
+FAIL=0
+
+# ── Temp workspace for wrapper scripts ────────────────────────────────────────
+WRAP_DIR="$(mktemp -d)"
+trap 'rm -rf "$WRAP_DIR"' EXIT
+
+# ── Helper: build a minimal fake release index JSON ───────────────────────────
+_fake_index() {
+    local ver="$1" date="$2"
+    printf '[{"version":"v%s","date":"%s","files":[],"npm":"10.0.0","v8":"","uv":"","zlib":"","openssl":"","modules":"","lts":false,"security":false}]' "$ver" "$date"
+}
+
+# ── Helper: install wrapper scripts into WRAP_DIR ─────────────────────────────
+# Args:
+#   $1  node version string to fake (e.g. "20.11.0")
+#   $2  content that the fake curl should write to its first positional argument
+#       (the script redirects: curl ... > "$TMPFILE", so the wrapper writes to $1)
+#   $3  exit code for the fake curl (default 0)
+_setup_wrappers() {
+    local node_ver="$1"
+    local curl_body="$2"
+    local curl_exit="${3:-0}"
+    local real_node
+    real_node="$(command -v node)"
+
+    # node wrapper: intercepts --version, delegates everything else to the real node
+    cat > "$WRAP_DIR/node" <<NODEEOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--version" ]]; then
+    echo "v${node_ver}"
+    exit 0
+fi
+exec "${real_node}" "\$@"
+NODEEOF
+    chmod +x "$WRAP_DIR/node"
+
+    # curl wrapper: writes the fake index body to the file given by the last
+    # positional argument that follows '>' in the caller's redirect.
+    # The script calls: curl ... > "$TMPFILE"
+    # So the shell redirect is handled by the shell itself — curl just needs
+    # to write to stdout and the shell writes it to the temp file.
+    cat > "$WRAP_DIR/curl" <<CURLEOF
+#!/usr/bin/env bash
+# Ignore all flags; just emit the fake body and exit
+printf '%s' $(printf '%q' "$curl_body")
+exit ${curl_exit}
+CURLEOF
+    chmod +x "$WRAP_DIR/curl"
+}
+
+# ── Test runner ───────────────────────────────────────────────────────────────
+_test() {
+    local name="$1"
+    local expected_exit="$2"
+    local expected_pattern="${3:-}"
+    shift 3
+    # Remaining args are exported env vars (KEY=VAL)
+
+    local output exit_code
+    set +e
+    output="$(PATH="$WRAP_DIR:$PATH" env "$@" bash "$SCRIPT" 2>&1)"
+    exit_code=$?
+    set -e
+
+    local ok=true
+    if [[ "$exit_code" -ne "$expected_exit" ]]; then
+        ok=false
+    fi
+    if [[ -n "$expected_pattern" ]] && ! echo "$output" | grep -q "$expected_pattern"; then
+        ok=false
+    fi
+
+    if $ok; then
+        echo "PASS: $name"
+        (( PASS++ )) || true
+    else
+        echo "FAIL: $name"
+        echo "  expected exit=${expected_exit} pattern='${expected_pattern}', got exit=${exit_code}"
+        echo "  output: $output"
+        (( FAIL++ )) || true
+    fi
+}
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+# 1. Check disabled when MINIMUM_NODE_RELEASE_AGE=0
+_setup_wrappers "20.11.0" "[]"
+_test "MINIMUM_NODE_RELEASE_AGE=0 disables check" \
+    0 "check disabled" \
+    MINIMUM_NODE_RELEASE_AGE=0
+
+# 2. Version old enough is accepted
+_setup_wrappers "20.11.0" "$(_fake_index "20.11.0" "2015-06-01")"
+_test "old version (2015) is accepted" \
+    0 "OK:" \
+    MINIMUM_NODE_RELEASE_AGE=1440
+
+# 3. Version released today is rejected
+_setup_wrappers "20.11.0" "$(_fake_index "20.11.0" "$(date +%Y-%m-%d)")"
+_test "version released today is rejected" \
+    1 "REJECTED:" \
+    MINIMUM_NODE_RELEASE_AGE=1440
+
+# 4. Rejection message includes release date and remaining time
+_setup_wrappers "20.11.0" "$(_fake_index "20.11.0" "$(date +%Y-%m-%d)")"
+_test "rejection message contains date and 'minutes'" \
+    1 "minutes" \
+    MINIMUM_NODE_RELEASE_AGE=1440
+
+# 5. Network error (curl exits 1) causes exit 1
+_setup_wrappers "20.11.0" "" 1
+_test "network error causes exit 1 with error message" \
+    1 "ERROR" \
+    MINIMUM_NODE_RELEASE_AGE=1440
+
+# 6. Version absent from index causes exit 1
+_setup_wrappers "20.11.0" "$(_fake_index "18.0.0" "2020-01-01")"
+_test "version not in index causes exit 1" \
+    1 "ERROR" \
+    MINIMUM_NODE_RELEASE_AGE=1440
+
+# 7. Version 2 days old passes a 1440-minute threshold
+if date -d "2 days ago" +%Y-%m-%d &>/dev/null 2>&1; then
+    TWO_DAYS_AGO="$(date -d '2 days ago' +%Y-%m-%d)"
+else
+    TWO_DAYS_AGO="$(date -j -v-2d +%Y-%m-%d)"
+fi
+_setup_wrappers "20.11.0" "$(_fake_index "20.11.0" "$TWO_DAYS_AGO")"
+_test "version 2 days old passes 1440-min threshold" \
+    0 "OK:" \
+    MINIMUM_NODE_RELEASE_AGE=1440
+
+# 8. Custom threshold: version 5 days old is rejected when threshold is 10 days (14400 min)
+if date -d "5 days ago" +%Y-%m-%d &>/dev/null 2>&1; then
+    FIVE_DAYS_AGO="$(date -d '5 days ago' +%Y-%m-%d)"
+else
+    FIVE_DAYS_AGO="$(date -j -v-5d +%Y-%m-%d)"
+fi
+_setup_wrappers "20.11.0" "$(_fake_index "20.11.0" "$FIVE_DAYS_AGO")"
+_test "version 5 days old rejected with 14400-min (10-day) threshold" \
+    1 "REJECTED:" \
+    MINIMUM_NODE_RELEASE_AGE=14400
+
+# 9. Custom threshold of 0 accepts any version even released today
+_setup_wrappers "20.11.0" "$(_fake_index "20.11.0" "$(date +%Y-%m-%d)")"
+_test "MINIMUM_NODE_RELEASE_AGE=0 accepts even today's release" \
+    0 "check disabled" \
+    MINIMUM_NODE_RELEASE_AGE=0
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Fixes #96 — adds a supply-chain security guard that validates the installed Node.js version is old enough before it is used during the frontend build.

## What was changed

- **`scripts/check-node-version-age.sh`** — new script that reads `MINIMUM_NODE_RELEASE_AGE` (default **1440 minutes = 24 hours**), queries the official Node.js release index, computes the version age, and exits 1 with a clear rejection message (version, release date, minutes remaining) if the version is too new.
- **`tests/test_check_node_version_age.sh`** — 9 unit tests covering accepted/rejected/disabled/network-error/unknown-version/custom-threshold scenarios.
- **`build.sh`** — calls the age check before `npm install`.
- **`.github/workflows/ci.yml`** — two new steps in `frontend-typecheck`: run the check and run the test suite.
- **`docs/security.md`** — new *Node.js Supply-Chain Protection* section.
- **`README.md`** — `MINIMUM_NODE_RELEASE_AGE` added to the configuration table.
- **`.env.example`** — documented with inline comment.

## Testing

```bash
bash tests/test_check_node_version_age.sh   # 9 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)