### PR TITLE
Release: merge dev to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,10 +48,23 @@ BLOCKEXPLORER_URL=https://mempool.space/address/
 # are recomputed from local findings on the same schedule.
 BLOCKEXPLORER_POLL_SEC=600
 
+# ── Build-time variables (no effect at server runtime) ────────────────────────
+
+# Number of parallel C++ compile jobs. Default 1 to keep peak RAM low on
+# memory-constrained hosts. Each Crow/Boost-heavy translation unit can spike to
+# 300–500 MB; running several in parallel quickly exhausts RAM on a shared server.
+# Raise only if you have measured headroom (e.g. BUILD_JOBS=2 on a 4 GB host
+# with no other heavy processes running).
+BUILD_JOBS=1
+
+# Set to ON if the system has libsqlite3-dev installed. Avoids compiling
+# SQLiteCpp from source, saving ~50 MB peak RAM and build time.
+# Install with: sudo apt-get install -y libsqlite3-dev
+PUZZPOOL_USE_SYSTEM_SQLITECPP=OFF
+
 # Supply-chain guard: minimum age (in minutes) a Node.js release must have before
 # it is used during the frontend build step (scripts/check-node-version-age.sh).
 # Default 1440 = 24 hours. Set to 0 to disable (not recommended in production).
-# This variable is read at build time only; it has no effect at server runtime.
 MINIMUM_NODE_RELEASE_AGE=1440
 
 # Keyspace definitions — any number of KEYSPACE_<NAME>=<start_hex>:<end_hex> entries.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
           sudo apt-get install -y cmake build-essential libboost-dev libasio-dev nlohmann-json3-dev libssl-dev
 
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPUZZPOOL_BUILD_TESTS=ON
 
       - name: Build
         run: cmake --build build -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,12 @@ option(PUZZPOOL_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option(PUZZPOOL_USE_SYSTEM_CROW "Use installed Crow package instead of bundled third_party/crow" OFF)
 option(PUZZPOOL_USE_SYSTEM_SQLITECPP "Use installed SQLiteCpp package instead of bundled third_party/SQLiteCpp" OFF)
 option(PUZZPOOL_SUPPRESS_THIRD_PARTY_WARNINGS "Suppress warnings from bundled/system third-party code" ON)
-option(PUZZPOOL_BUILD_TESTS "Build the Catch2 test suite" ON)
+# Default OFF so production builds (build.sh) don't compile Catch2 + 9 test binaries.
+# CI enables this explicitly with -DPUZZPOOL_BUILD_TESTS=ON.
+option(PUZZPOOL_BUILD_TESTS "Build the Catch2 test suite" OFF)
+# Adds compiler flags that reduce peak RAM during compilation with negligible
+# impact on the resulting binary. Recommended for memory-constrained build hosts.
+option(PUZZPOOL_LOW_MEMORY_BUILD "Add compiler flags to reduce peak build RAM" OFF)
 
 # ── puzzpool_core static library (everything except main.cpp) ─────────────────
 # Tests link against this target; the server executable links it + main.cpp.
@@ -102,6 +107,22 @@ endforeach()
 # the executable target so puzzpool_core still warns on our own code.
 if(NOT MSVC)
     target_compile_options(puzzpool PRIVATE -Wno-null-dereference)
+endif()
+
+# ── Low-memory build flags ────────────────────────────────────────────────────
+# These flags reduce peak compiler RAM at -O2 with negligible binary impact.
+# Enabled automatically by build.sh; also set via -DPUZZPOOL_LOW_MEMORY_BUILD=ON.
+if(PUZZPOOL_LOW_MEMORY_BUILD AND NOT MSVC)
+    foreach(_tgt puzzpool_core puzzpool)
+        target_compile_options(${_tgt} PRIVATE
+            # Skips per-assignment variable-location tracking that -O2 normally
+            # does for debug info. The biggest single RAM saver in GCC/Clang.
+            -fno-var-tracking-assignments
+        )
+    endforeach()
+    message(STATUS "Low-memory build flags:          ON (-fno-var-tracking-assignments)")
+else()
+    message(STATUS "Low-memory build flags:          OFF")
 endif()
 
 find_package(Threads REQUIRED)
@@ -270,4 +291,5 @@ message(STATUS "Use system Crow:                 ${PUZZPOOL_USE_SYSTEM_CROW}")
 message(STATUS "Use system SQLiteCpp:            ${PUZZPOOL_USE_SYSTEM_SQLITECPP}")
 message(STATUS "Suppress third-party warnings:   ${PUZZPOOL_SUPPRESS_THIRD_PARTY_WARNINGS}")
 message(STATUS "Build tests:                     ${PUZZPOOL_BUILD_TESTS}")
+message(STATUS "Low-memory build:                ${PUZZPOOL_LOW_MEMORY_BUILD}")
 message(STATUS "========================================")

--- a/README.md
+++ b/README.md
@@ -162,6 +162,46 @@ sudo nginx -t && sudo systemctl reload nginx
 sudo certbot --nginx -d your.domain.com
 ```
 
+### Low-memory builds
+
+On servers where other services are running alongside puzzpool, the C++ build can
+exhaust RAM if multiple translation units compile in parallel (each Crow/Boost-heavy
+file peaks at 300–500 MB).
+
+`build.sh` is already tuned for this: it defaults to **1 parallel job**, skips the
+test suite, and enables `-fno-var-tracking-assignments` (the biggest single RAM saver
+in GCC/Clang at `-O2`). The knobs are all env vars — no script editing needed:
+
+```bash
+# Minimal-RAM build (defaults; already set in build.sh)
+BUILD_JOBS=1 ./build.sh
+
+# If you have libsqlite3-dev installed, skip compiling SQLiteCpp from source
+PUZZPOOL_USE_SYSTEM_SQLITECPP=ON BUILD_JOBS=1 ./build.sh
+
+# Faster build on a machine with plenty of RAM (e.g. a dedicated CI worker)
+BUILD_JOBS=4 PUZZPOOL_BUILD_TESTS=ON ./build.sh
+```
+
+| Variable | Default in `build.sh` | Description |
+|----------|-----------------------|-------------|
+| `BUILD_JOBS` | `1` | Parallel C++ compile jobs. Keep at `1` on shared/low-RAM hosts. |
+| `PUZZPOOL_BUILD_TESTS` | `OFF` | Build Catch2 test suite. Enable in CI; skip on prod. |
+| `PUZZPOOL_USE_SYSTEM_SQLITECPP` | `OFF` | Use system `libsqlite3-dev` instead of compiling from source. |
+
+If you still run out of memory with `BUILD_JOBS=1`, adding a small swap file is the
+most reliable fallback:
+
+```bash
+sudo fallocate -l 1G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+# Make permanent: add "/swapfile none swap sw 0 0" to /etc/fstab
+```
+
+---
+
 ### Routine update (after `git pull`)
 
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,29 @@ set -euo pipefail
 
 BUILD_DIR="build"
 
+# ── Parallelism ───────────────────────────────────────────────────────────────
+# Default to 1 to keep peak RAM low on memory-constrained hosts.
+# Each C++ translation unit (especially Crow/Boost headers) can spike to
+# 300–500 MB. On a server with other services running, set this to 1 unless
+# you know you have headroom.
+# Override: BUILD_JOBS=4 ./build.sh
+BUILD_JOBS="${BUILD_JOBS:-1}"
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+# Skip building the test suite on production; CI enables it explicitly.
+# Building 9 test binaries + Catch2 adds significant compilation time and RAM
+# with no benefit on a deployment host.
+# Override: PUZZPOOL_BUILD_TESTS=ON ./build.sh
+PUZZPOOL_BUILD_TESTS="${PUZZPOOL_BUILD_TESTS:-OFF}"
+
+# ── SQLiteCpp ────────────────────────────────────────────────────────────────
+# If the system has libsqlite3-dev installed, using PUZZPOOL_USE_SYSTEM_SQLITECPP=ON
+# skips compiling SQLiteCpp from source (saves ~50 MB peak RAM and time).
+# The system package is already present on Ubuntu/Debian when you install
+# libsqlite3-dev. Default OFF to stay safe on hosts without the package.
+# Override: PUZZPOOL_USE_SYSTEM_SQLITECPP=ON ./build.sh
+PUZZPOOL_USE_SYSTEM_SQLITECPP="${PUZZPOOL_USE_SYSTEM_SQLITECPP:-OFF}"
+
 echo "[update] sync submodule config"
 git submodule sync --recursive
 
@@ -10,10 +33,14 @@ echo "[update] checkout pinned submodule commits"
 git submodule update --init --recursive
 
 echo "[build] configure"
-cmake -S . -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B "$BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPUZZPOOL_BUILD_TESTS="${PUZZPOOL_BUILD_TESTS}" \
+    -DPUZZPOOL_USE_SYSTEM_SQLITECPP="${PUZZPOOL_USE_SYSTEM_SQLITECPP}" \
+    -DPUZZPOOL_LOW_MEMORY_BUILD=ON
 
-echo "[build] build incrementally"
-cmake --build "$BUILD_DIR" -j
+echo "[build] build incrementally (jobs=${BUILD_JOBS})"
+cmake --build "$BUILD_DIR" -j"${BUILD_JOBS}"
 
 echo "[build] check Node.js release age (supply-chain guard)"
 bash "$(dirname "$0")/scripts/check-node-version-age.sh"


### PR DESCRIPTION
Merges all changes accumulated on `dev` into `main`.

## Commits included

- `0f79b49` fix: reduce peak build RAM on memory-constrained production hosts

## Changes

- `build.sh` — `BUILD_JOBS=1` default; `PUZZPOOL_BUILD_TESTS=OFF`; `PUZZPOOL_USE_SYSTEM_SQLITECPP` passthrough; `PUZZPOOL_LOW_MEMORY_BUILD=ON`
- `CMakeLists.txt` — `PUZZPOOL_BUILD_TESTS` default OFF; new `PUZZPOOL_LOW_MEMORY_BUILD` option adding `-fno-var-tracking-assignments`
- `.github/workflows/ci.yml` — explicit `-DPUZZPOOL_BUILD_TESTS=ON` in configure step
- `README.md` — new *Low-memory builds* section
- `.env.example` — `BUILD_JOBS` and `PUZZPOOL_USE_SYSTEM_SQLITECPP` documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)