### PR TITLE
chore: issue templates for bug / feature idea / implementation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug Report
+description: Something is broken. Goes straight into the development workflow — no story needed.
+title: "[Bug]: "
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! The `type:bug` label this form applies routes the issue
+        directly into the development workflow.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you see, and what did you expect to happen instead?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this bug?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Version / Environment
+      description: Version, commit, browser, or host where you saw the bug.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Paste any log output or attach screenshots.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+blank_issues_enabled: true
+# A blank issue (no template, no labels) is treated as a feature idea: the
+# orchestrator claims it for the userstory workflow and stamps feature-idea.
+# Bugs MUST use the Bug Report form so they carry type:bug.

--- a/.github/ISSUE_TEMPLATE/feature_idea.yml
+++ b/.github/ISSUE_TEMPLATE/feature_idea.yml
@@ -1,0 +1,38 @@
+name: Feature Idea
+description: Propose an idea. It is refined into a ready user story in this issue — no code is written in this stage.
+labels: ["feature-idea"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe your idea — the userstory workflow (PO, architect, UX designer) refines it
+        **in this issue** into a Definition-of-Ready story. It ends at `status:ready` and stays
+        open as a backlog item. Development starts later, when someone opens an implementation
+        issue referencing it with a `Story: #<n>` line.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Idea
+      description: What problem should be solved, or what would you like to see?
+    validations:
+      required: true
+  - type: textarea
+    id: users
+    attributes:
+      label: Who benefits?
+      description: Target users or situations where this matters.
+    validations:
+      required: false
+  - type: textarea
+    id: value
+    attributes:
+      label: Why is it valuable?
+    validations:
+      required: false
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints or context
+      description: Anything the refinement should know — technical constraints, related issues, deadlines.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/implementation.md
+++ b/.github/ISSUE_TEMPLATE/implementation.md
@@ -1,0 +1,24 @@
+---
+name: Implementation issue
+about: Start development of a ready story from the backlog. The Story line below routes this issue into the development workflow.
+title: ''
+labels: ''
+assignees: ''
+---
+
+Story: #
+
+<!--
+Complete the line above with the number of a READY story, keeping exactly this
+format: "Story: #123" on its own line. It routes this issue into the
+development workflow, and PO intake verifies the story carries status:ready —
+issues referencing an unfinished story are rejected.
+
+Optional: add the `workflow:full` label for the 6-role flow (architect, tester,
+designer included); the default is the lean 3-role flow.
+-->
+
+## Scope notes (optional)
+
+<!-- Anything specific to THIS implementation slice. The requirements live in
+     the story — do not duplicate its acceptance criteria here. -->


### PR DESCRIPTION
## Why

The orchestrator routes new issues by shape: a plain idea becomes a userstory, a `Story: #<n>` body line makes an implementation issue, and `type:bug` goes straight to development. The one case that cannot self-heal is an unlabeled bug report (it would be refined as a feature idea), so bug reports need a template that applies `type:bug`. The other two templates make the intended flow obvious to anyone clicking "New Issue".

## Templates

- **Bug Report** (YAML form) — applies `type:bug`; structured fields for what happened, reproduction steps, environment, and logs. Routes directly into the development workflow.
- **Feature Idea** (YAML form) — applies `feature-idea`; collects problem, audience, value, and constraints so the PO's first refinement pass starts from structured input. (Blank issues work too — the orchestrator claims them for the userstory workflow automatically once gitonator PR #113 is deployed.)
- **Implementation issue** (classic markdown) — body pre-filled with a `Story: #` line to complete. A YAML form cannot produce the exact `Story: #<n>` line the intake gate parses, hence the markdown format. Explains that premature issues (story not `status:ready`) are rejected.
- **config.yml** — keeps blank issues enabled (a blank issue is a valid feature idea by design).

Templates take effect once this lands on `main` (GitHub reads them from the default branch only).
