### PR TITLE
fix: remove sticky-column visual treatment regression (closes #115)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -529,7 +529,9 @@
         }
 
         tbody tr:last-child td { border-bottom: none; }
-        tbody tr:hover td { background: rgba(255,255,255,0.02); }
+        tbody tr:hover td:not(.sticky-col-left-1):not(.sticky-col-left-2):not(.sticky-col-right) {
+            background: rgba(255,255,255,0.02);
+        }
 
         .td-name { color: var(--text-primary); }
         .td-speed { color: var(--accent-green); }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -550,7 +550,6 @@
         .sticky-col-right {
             position: sticky;
             z-index: 2;
-            background: var(--bg-secondary);
             background-clip: padding-box;
         }
 
@@ -558,6 +557,7 @@
         .table-wrap-scroll-x thead .sticky-col-left-2,
         .table-wrap-scroll-x thead .sticky-col-right {
             z-index: 3;
+            background-image: linear-gradient(rgba(0,255,255,0.04), rgba(0,255,255,0.04));
         }
 
         .sticky-col-left-1 {
@@ -565,24 +565,23 @@
             width: var(--sticky-col-left-1-width);
             min-width: var(--sticky-col-left-1-width);
             text-align: center;
+            background-color: var(--bg-tertiary);
         }
 
         .sticky-col-left-2 {
             left: var(--sticky-col-left-2-left);
-            border-right: 1px solid var(--border-default);
-            box-shadow: 10px 0 12px -12px rgba(0,0,0,0.9);
+            background-color: var(--bg-tertiary);
         }
 
         .sticky-col-right {
             right: 0;
-            border-left: 1px solid var(--border-default);
-            box-shadow: -10px 0 12px -12px rgba(0,0,0,0.9);
+            background-color: var(--bg-secondary);
         }
 
         tbody tr:hover td.sticky-col-left-1,
         tbody tr:hover td.sticky-col-left-2,
         tbody tr:hover td.sticky-col-right {
-            background: #1a1a1a;
+            background-image: linear-gradient(rgba(255,255,255,0.02), rgba(255,255,255,0.02));
         }
 
         .worker-dot {
@@ -595,9 +594,6 @@
         .worker-dot-on  { background: var(--accent-green); box-shadow: 0 0 8px var(--accent-green); animation: pulse 2s ease-in-out infinite; }
         .worker-dot-off { background: var(--text-secondary); }
         .worker-dim td { color: var(--text-secondary) !important; }
-        .worker-dim td.sticky-col-left-1,
-        .worker-dim td.sticky-col-left-2,
-        .worker-dim td.sticky-col-right { background: #151515; }
 
         .api-block {
             background: linear-gradient(145deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%);

--- a/frontend/src/accessibility.test.ts
+++ b/frontend/src/accessibility.test.ts
@@ -121,11 +121,16 @@ describe('frontend accessibility regressions', () => {
     expect(rightBlock).not.toContain('border-left');
     expect(rightBlock).not.toContain('box-shadow');
 
-    // Body hover overlays a translucent white tint on the opaque base instead of a
-    // flat #1a1a1a fill, matching the non-sticky hover treatment.
+    // Generic row hover must exclude sticky cells so it does not reset their
+    // per-side opaque background-color to a translucent shorthand fill.
+    expect(html).toMatch(/tbody tr:hover td:not\(\.sticky-col-left-1\):not\(\.sticky-col-left-2\):not\(\.sticky-col-right\)\s*\{\s*background:\s*rgba\(255,255,255,0\.02\);/);
+
+    // Sticky-cell hover then adds only the translucent white overlay on top of
+    // that preserved opaque base instead of using a flat #1a1a1a fill.
     const hoverBlock = html.match(/tbody tr:hover td\.sticky-col-left-1,[\s\S]*?\{([^}]*)\}/)?.[1] ?? '';
     expect(hoverBlock).toMatch(/background-image:\s*linear-gradient\(rgba\(255,255,255,0\.02\),\s*rgba\(255,255,255,0\.02\)\)/);
     expect(hoverBlock).not.toContain('#1a1a1a');
+    expect(hoverBlock).not.toMatch(/\bbackground:\s*rgba\(255,255,255,0\.02\)/);
 
     // Dimmed/offline rows no longer override sticky cells with a distinct #151515 fill.
     expect(html).not.toContain('#151515');

--- a/frontend/src/accessibility.test.ts
+++ b/frontend/src/accessibility.test.ts
@@ -94,13 +94,47 @@ describe('frontend accessibility regressions', () => {
     expect(html).not.toMatch(/aria-label="Keys Found table, scroll horizontally"/);
   });
 
-  it('defines scoped sticky-column table styles with opaque backgrounds and separators', () => {
+  it('defines scoped sticky-column table styles with opaque per-side backgrounds, tinted sticky headers, and no separators', () => {
     expect(html).toMatch(/\.table-wrap-scroll-x\s*\{[\s\S]*overflow-x:\s*auto;[\s\S]*overflow-y:\s*hidden;/);
     expect(html).toMatch(/\.table-wrap-scroll-x:focus-visible\s*\{[\s\S]*outline:\s*2px solid rgba\(0,255,255,0\.45\);/);
     expect(html).toMatch(/\.table-wrap-scroll-x table\s*\{[\s\S]*width:\s*max-content;[\s\S]*min-width:\s*100%;/);
-    expect(html).toMatch(/\.sticky-col-left-1,\s*\.sticky-col-left-2,\s*\.sticky-col-right\s*\{[\s\S]*position:\s*sticky;[\s\S]*background:\s*var\(--bg-secondary\);/);
-    expect(html).toMatch(/\.sticky-col-left-2\s*\{[\s\S]*border-right:\s*1px solid var\(--border-default\);/);
-    expect(html).toMatch(/\.sticky-col-right\s*\{[\s\S]*border-left:\s*1px solid var\(--border-default\);/);
+
+    // The grouped base rule keeps sticky positioning but no longer paints a
+    // single shared flat fill — each column supplies its own opaque per-side base.
+    const groupedBase = html.match(/\.sticky-col-left-1,\s*\.sticky-col-left-2,\s*\.sticky-col-right\s*\{([^}]*)\}/)?.[1] ?? '';
+    expect(groupedBase).toContain('position: sticky');
+    expect(groupedBase).toContain('background-clip: padding-box');
+    expect(groupedBase).not.toMatch(/background:\s*var\(--bg-secondary\)/);
+
+    // Per-side opaque fill matches the local gradient tone: left edge -> --bg-tertiary,
+    // right edge -> --bg-secondary. Content must not bleed through pinned cells.
+    const left1Block = html.match(/\.sticky-col-left-1\s*\{([^}]*)\}/)?.[1] ?? '';
+    const left2Block = html.match(/\.sticky-col-left-2\s*\{([^}]*)\}/)?.[1] ?? '';
+    const rightBlock = html.match(/\.sticky-col-right\s*\{([^}]*right:\s*0;[^}]*)\}/)?.[1] ?? '';
+    expect(left1Block).toContain('background-color: var(--bg-tertiary)');
+    expect(left2Block).toContain('background-color: var(--bg-tertiary)');
+    expect(rightBlock).toContain('background-color: var(--bg-secondary)');
+
+    // Separator treatment (vertical line + scroll-edge shadow) is fully removed.
+    expect(left2Block).not.toContain('border-right');
+    expect(left2Block).not.toContain('box-shadow');
+    expect(rightBlock).not.toContain('border-left');
+    expect(rightBlock).not.toContain('box-shadow');
+
+    // Body hover overlays a translucent white tint on the opaque base instead of a
+    // flat #1a1a1a fill, matching the non-sticky hover treatment.
+    const hoverBlock = html.match(/tbody tr:hover td\.sticky-col-left-1,[\s\S]*?\{([^}]*)\}/)?.[1] ?? '';
+    expect(hoverBlock).toMatch(/background-image:\s*linear-gradient\(rgba\(255,255,255,0\.02\),\s*rgba\(255,255,255,0\.02\)\)/);
+    expect(hoverBlock).not.toContain('#1a1a1a');
+
+    // Dimmed/offline rows no longer override sticky cells with a distinct #151515 fill.
+    expect(html).not.toContain('#151515');
+
+    // Sticky header cells composite the cyan header tint over their opaque base so
+    // pinned headers match the tinted non-sticky header cells at rest.
+    const headerBlock = html.match(/\.table-wrap-scroll-x thead \.sticky-col-left-1,[\s\S]*?\{([^}]*)\}/)?.[1] ?? '';
+    expect(headerBlock).toContain('z-index: 3');
+    expect(headerBlock).toMatch(/background-image:\s*linear-gradient\(rgba\(0,255,255,0\.04\),\s*rgba\(0,255,255,0\.04\)\)/);
   });
 
   it('marks the sticky headers and cells for worker and score identity plus recency columns', () => {

--- a/review/2026-07-07-issue-115-pr-116-sticky-columns-background.md
+++ b/review/2026-07-07-issue-115-pr-116-sticky-columns-background.md
@@ -9,10 +9,10 @@ Author: rita-rev
 **Date:** 2026-07-07
 
 ### Verdict
-CHANGES REQUESTED
+APPROVED
 
 ### Summary
-The change removes the separator/shadow treatment and brings sticky headers into scope as planned, but the hover implementation still drops the sticky cells' opaque fill. The current tests all pass, yet they only assert the presence of a hover overlay and miss the cascade interaction that reintroduces transparency on hovered sticky cells.
+The follow-up commit fixes the prior hover-opacity regression by excluding sticky cells from the generic row-hover shorthand, so hovered pinned cells keep their opaque per-side base while still receiving the translucent overlay. The updated accessibility test now guards that exact cascade path, and the full frontend verification pass is green.
 
 ### Documentation Check
 - `README.md` — not needed for this CSS/test change
@@ -25,8 +25,7 @@ The change removes the separator/shadow treatment and brings sticky headers into
 ### Findings
 
 #### MUST FIX — blocking
-1. `frontend/index.html:532,581-584` — `tbody tr:hover td { background: rgba(255,255,255,0.02); }` still applies to sticky cells on hover and resets their `background-color` to a translucent fill. The new sticky hover rule only adds `background-image`, so hovered pinned cells no longer stay opaque and horizontally scrolled content can bleed through again, which regresses the stated AC-4 behavior. Fix this by preserving an opaque background color in the sticky hover state or by excluding sticky cells from the generic hover shorthand.
-2. `frontend/src/accessibility.test.ts:124-128` — the rewritten hover assertion checks only for the `background-image` overlay and does not guard the final hovered sticky-cell background from the regression above. Add coverage that proves hovered sticky cells retain an opaque base, not just that the overlay rule exists.
+None.
 
 #### SHOULD FIX — non-blocking but important
 None.
@@ -36,19 +35,19 @@ None.
 
 ### Test Review
 
-**Test suite result:** After `npm ci`, `npm run typecheck`, `npx vitest run`, and `npm run build` all passed. Vitest reported 37/37 tests passing across 3 files.
+**Test suite result:** `npm run typecheck`, `npx vitest run`, and `npm run build` all passed on the current PR head. Vitest reported 37/37 tests passing across 3 files.
 
 **Test files reviewed:**
-- `frontend/src/accessibility.test.ts` — reviewed the sticky-column regression coverage added for per-side backgrounds, separator removal, header tint, hover, and dim behavior.
+- `frontend/src/accessibility.test.ts` — reviewed the sticky-column regression coverage for per-side backgrounds, separator removal, hover-opacity preservation, header tint, and dim behavior.
 
 **Coverage assessment:**
-- Well covered: sticky positioning is preserved; separator and shadow declarations are removed; header tint overlay is asserted; the dim override removal is asserted.
-- NOT covered (missing tests): the effective hovered sticky-cell background after the generic row-hover rule and sticky-cell hover rule cascade together.
+- Well covered: sticky positioning is preserved; separator and shadow declarations are removed; sticky cells keep an opaque base during hover; header tint overlay is asserted; the dim override removal is asserted.
+- NOT covered (missing tests): none identified in automated coverage for the changed CSS/test surface. Manual deployed-site visual verification remains a separate non-CLI check.
 
 **Test quality findings:**
-1. MUST FIX — `frontend/src/accessibility.test.ts:124-128` does not verify that hovered sticky cells remain opaque after cascade resolution, so the current regression passes the suite.
+None.
 
-**Overall test verdict:** Inadequate until the hover-opacity regression is covered.
+**Overall test verdict:** Adequate for code review.
 
 ### Security Assessment
 No concerns identified.
@@ -59,12 +58,11 @@ No concerns identified.
 ### Positive Observations
 - The separator/shadow removal is clean and tightly scoped to the sticky-column rules.
 - Reusing the header-scoped sticky rule for the cyan tint overlay is the right seam for the plan-review blocker.
-- Verification is fast and reproducible once frontend dependencies are installed.
+- The hover fix addresses the actual cascade root cause with minimal CSS churn.
+- The updated accessibility test now guards the exact regression path that caused the prior review failure.
 
 ### Required Next Steps for Developer
-1. Adjust the sticky hover CSS so pinned cells keep an opaque base while hovered.
-2. Extend `frontend/src/accessibility.test.ts` to fail when the generic hover rule can override sticky-cell opacity.
-3. Re-run `npm run typecheck`, `npx vitest run`, and `npm run build`, then return the PR for review.
+1. None.
 
 ### Routing
-Transitioning `status:code-review` -> `status:in-development` because the PR has a blocking correctness regression in the sticky hover state and needs developer changes before it can move forward.
+Transitioning `status:code-review` -> `status:po-approval` because the prior hover-opacity blocker is fixed, the regression test now covers that cascade path, and the PR is ready for product-owner approval.

--- a/review/2026-07-07-issue-115-pr-116-sticky-columns-background.md
+++ b/review/2026-07-07-issue-115-pr-116-sticky-columns-background.md
@@ -1,0 +1,70 @@
+Author: rita-rev
+
+## Code Review Report
+
+**PR:** #116 — fix: remove sticky-column visual treatment regression (closes #115)
+**Issue:** #115
+**Branch:** `fix/115-sticky-columns-background`
+**Reviewer:** rita-rev
+**Date:** 2026-07-07
+
+### Verdict
+CHANGES REQUESTED
+
+### Summary
+The change removes the separator/shadow treatment and brings sticky headers into scope as planned, but the hover implementation still drops the sticky cells' opaque fill. The current tests all pass, yet they only assert the presence of a hover overlay and miss the cascade interaction that reintroduces transparency on hovered sticky cells.
+
+### Documentation Check
+- `README.md` — not needed for this CSS/test change
+- API reference — not needed
+- `CHANGELOG.md` — not needed
+- `docs/architecture/` — not needed
+- Inline code docs — not needed
+- `.env.example` — not needed
+
+### Findings
+
+#### MUST FIX — blocking
+1. `frontend/index.html:532,581-584` — `tbody tr:hover td { background: rgba(255,255,255,0.02); }` still applies to sticky cells on hover and resets their `background-color` to a translucent fill. The new sticky hover rule only adds `background-image`, so hovered pinned cells no longer stay opaque and horizontally scrolled content can bleed through again, which regresses the stated AC-4 behavior. Fix this by preserving an opaque background color in the sticky hover state or by excluding sticky cells from the generic hover shorthand.
+2. `frontend/src/accessibility.test.ts:124-128` — the rewritten hover assertion checks only for the `background-image` overlay and does not guard the final hovered sticky-cell background from the regression above. Add coverage that proves hovered sticky cells retain an opaque base, not just that the overlay rule exists.
+
+#### SHOULD FIX — non-blocking but important
+None.
+
+#### NIT / SUGGESTION — optional
+None.
+
+### Test Review
+
+**Test suite result:** After `npm ci`, `npm run typecheck`, `npx vitest run`, and `npm run build` all passed. Vitest reported 37/37 tests passing across 3 files.
+
+**Test files reviewed:**
+- `frontend/src/accessibility.test.ts` — reviewed the sticky-column regression coverage added for per-side backgrounds, separator removal, header tint, hover, and dim behavior.
+
+**Coverage assessment:**
+- Well covered: sticky positioning is preserved; separator and shadow declarations are removed; header tint overlay is asserted; the dim override removal is asserted.
+- NOT covered (missing tests): the effective hovered sticky-cell background after the generic row-hover rule and sticky-cell hover rule cascade together.
+
+**Test quality findings:**
+1. MUST FIX — `frontend/src/accessibility.test.ts:124-128` does not verify that hovered sticky cells remain opaque after cascade resolution, so the current regression passes the suite.
+
+**Overall test verdict:** Inadequate until the hover-opacity regression is covered.
+
+### Security Assessment
+No concerns identified.
+
+### Performance Notes
+No concerns identified.
+
+### Positive Observations
+- The separator/shadow removal is clean and tightly scoped to the sticky-column rules.
+- Reusing the header-scoped sticky rule for the cyan tint overlay is the right seam for the plan-review blocker.
+- Verification is fast and reproducible once frontend dependencies are installed.
+
+### Required Next Steps for Developer
+1. Adjust the sticky hover CSS so pinned cells keep an opaque base while hovered.
+2. Extend `frontend/src/accessibility.test.ts` to fail when the generic hover rule can override sticky-cell opacity.
+3. Re-run `npm run typecheck`, `npx vitest run`, and `npm run build`, then return the PR for review.
+
+### Routing
+Transitioning `status:code-review` -> `status:in-development` because the PR has a blocking correctness regression in the sticky hover state and needs developer changes before it can move forward.


### PR DESCRIPTION
Fixes #115

Implements Story #114 — removes the unintended dark fill, vertical separator line, and scroll-edge shadow from sticky dashboard columns introduced in #110/#111, while preserving sticky positioning.

## What changed
- **Per-side opaque fill** on pinned columns matching the table gradient tone (left → `--bg-tertiary`, right → `--bg-secondary`), so horizontally scrolled content still cannot bleed through pinned cells.
- **Separators removed** — the vertical border and edge shadow are gone from the left/right pinned columns.
- **Sticky header tint** — pinned header cells composite the cyan header tint over their opaque base so they match the tinted non-sticky header row at rest (closes the reviewer's plan-review MUST FIX).
- **Hover** now overlays a translucent-white tint matching the non-sticky hover instead of a flat `#1a1a1a`; the distinct dimmed/offline sticky override is dropped.

Sticky positioning, offsets, `z-index`, widths, and accessibility behaviour are unchanged.

## Tests
`frontend/src/accessibility.test.ts` updated to assert per-side opaque backgrounds, tinted sticky headers, hover-overlay behaviour, and the absence of separators / dim override, plus a header-tint regression guard.

```bash
cd frontend && npm ci && npm run typecheck && npx vitest run
```
All 37 tests pass; typecheck clean; production build succeeds.

Implementation follows the plan approved by the Reviewer on issue #115.