### PR TITLE
fix: add named group semantics to visualization filters (#128)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,6 +49,40 @@ This runs `tsc --noEmit` (strict type check) followed by `vite build` (bundle to
 
 ---
 
+## Frontend Unit Tests (Vitest)
+
+```bash
+npm test --prefix frontend
+```
+
+This runs the Vitest suite (`vitest run`) over `frontend/src/*.test.ts`. All tests must
+pass before a frontend change is merged.
+
+### Test coverage
+
+| File | What is verified |
+|------|-----------------|
+| `frontend/src/format.test.ts` | Number/hex/duration formatting helpers |
+| `frontend/src/performance.test.ts` | Performance-sensitive rendering helpers |
+| `frontend/src/accessibility.test.ts` | Accessibility regressions in the built dashboard markup |
+
+### Accessibility regression tests
+
+`accessibility.test.ts` asserts against `frontend/index.html` to lock in accessible
+markup. Covered guarantees include:
+
+- Filter buttons manage `aria-pressed` state and the dashboard logic keeps it in sync.
+- Each visualization filter set is exposed as a **named group** in the accessibility
+  tree: the Night Sky Heatmap layer filter (`#hm-layer-filter`), the Allocator
+  Diagnostics generation filter (`#alloc-generation-filter`), and the Hilbert Curve
+  Mapping layer filter (`#hil-layer-filter`) each carry `role="group"` and a unique
+  `aria-label` naming the visualization and filter dimension.
+
+When adding or renaming a filter group in `frontend/index.html`, update these
+assertions so the accessible-name contract stays enforced.
+
+---
+
 ## Smoke Test (local server)
 
 ```bash

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1144,7 +1144,7 @@
         <div class="heatmap-wrap">
             <div class="keyspace-label">
                 <span>Night Sky Heatmap</span>
-                <div class="alloc-filter-group" id="hm-layer-filter">
+                <div class="alloc-filter-group" id="hm-layer-filter" role="group" aria-label="Night Sky Heatmap layer filter">
                     <button class="alloc-filter-btn" data-layer="all" aria-pressed="false">All</button>
                     <button class="alloc-filter-btn active" data-layer="completed" aria-pressed="true">Done</button>
                     <button class="alloc-filter-btn" data-layer="assigned" aria-pressed="false">In Progress</button>
@@ -1218,7 +1218,7 @@
         <div class="heatmap-wrap alloc-diagnostics-wrap" id="allocator-diagnostics-wrap">
             <div class="alloc-filter-row">
                 <div class="alloc-filter-label">Generation</div>
-                <div class="alloc-filter-group" id="alloc-generation-filter">
+                <div class="alloc-filter-group" id="alloc-generation-filter" role="group" aria-label="Allocator Diagnostics generation filter">
                     <button class="alloc-filter-btn" data-gen="all" aria-pressed="false">All</button>
                     <button class="alloc-filter-btn" data-gen="legacy" aria-pressed="false">Legacy</button>
                     <button class="alloc-filter-btn" data-gen="affine" aria-pressed="false">Affine</button>
@@ -1273,7 +1273,7 @@
         <div class="hilbert-wrap">
             <div class="keyspace-label">
                 <span>Hilbert Curve Mapping (Full Scale)</span>
-                <div class="alloc-filter-group" id="hil-layer-filter">
+                <div class="alloc-filter-group" id="hil-layer-filter" role="group" aria-label="Hilbert Curve Mapping layer filter">
                     <button class="alloc-filter-btn" data-layer="all" aria-pressed="false">All</button>
                     <button class="alloc-filter-btn active" data-layer="native" aria-pressed="true">Native</button>
                     <button class="alloc-filter-btn" data-layer="blocked" aria-pressed="false">Blocked</button>

--- a/frontend/src/accessibility.test.ts
+++ b/frontend/src/accessibility.test.ts
@@ -26,6 +26,38 @@ describe('frontend accessibility regressions', () => {
     expect(html).toMatch(/data-layer="native"\s+aria-pressed="true"/);
   });
 
+  it('exposes each visualization filter set as a named group in the accessibility tree', () => {
+    expect(html).toMatch(
+      /<div class="alloc-filter-group" id="hm-layer-filter" role="group" aria-label="Night Sky Heatmap layer filter">/,
+    );
+    expect(html).toMatch(
+      /<div class="alloc-filter-group" id="alloc-generation-filter" role="group" aria-label="Allocator Diagnostics generation filter">/,
+    );
+    expect(html).toMatch(
+      /<div class="alloc-filter-group" id="hil-layer-filter" role="group" aria-label="Hilbert Curve Mapping layer filter">/,
+    );
+  });
+
+  it('gives each filter group a unique aria-label identifying its visualization and dimension', () => {
+    const labels = [...html.matchAll(/<div class="alloc-filter-group"[^>]*aria-label="([^"]+)"/g)].map(
+      (m) => m[1],
+    );
+    expect(labels).toEqual([
+      'Night Sky Heatmap layer filter',
+      'Allocator Diagnostics generation filter',
+      'Hilbert Curve Mapping layer filter',
+    ]);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it('marks every filter group container with role="group"', () => {
+    const groups = html.match(/<div class="alloc-filter-group"[^>]*>/g) ?? [];
+    expect(groups).toHaveLength(3);
+    for (const group of groups) {
+      expect(group).toContain('role="group"');
+    }
+  });
+
   it('synchronizes filter button aria-pressed state in dashboard logic', () => {
     expect(dashboardTs).toMatch(/setAttribute\('aria-pressed', String\(isActive\)\)/);
   });


### PR DESCRIPTION
## Summary
Adds `role="group"` and a unique, descriptive `aria-label` to each of the three visualization filter containers so screen-reader users can tell which visualization and dimension each All/Done/In Progress / layer / generation button set controls.

## Changes
- `frontend/index.html` — `role="group"` + `aria-label` on `#hm-layer-filter` (Night Sky Heatmap layer filter), `#alloc-generation-filter` (Allocator Diagnostics generation filter), and `#hil-layer-filter` (Hilbert Curve Mapping layer filter). Button text, `aria-pressed` handling, behavior, and styling unchanged.
- `frontend/src/accessibility.test.ts` — three new assertions covering the named groups, unique labels, and that every filter container carries `role="group"`.

## Fixes / References
Closes #128

## Testing
- `cd frontend && npm test` — 40 tests pass (19 accessibility)
- `cd frontend && npm run build` — passes (tsc + vite)

## Next Step
Reviewer role: please review the accessibility semantics against issue #128 acceptance criteria.